### PR TITLE
Add URL secret autofill for 2FA landing

### DIFF
--- a/2FA_landing/index.html
+++ b/2FA_landing/index.html
@@ -1,0 +1,500 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OBJOPA 2FA</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: radial-gradient(circle at 20% 20%, #1c2740 0%, #0f172a 35%, #0b1224 100%);
+      --glass: rgba(255, 255, 255, 0.08);
+      --border: rgba(255, 255, 255, 0.12);
+      --accent: #7c3aed;
+      --accent-2: #22d3ee;
+      --text-main: #e2e8f0;
+      --muted: #94a3b8;
+      --error: #f87171;
+      --success: #34d399;
+      font-family: "Inter", "SF Pro Display", system-ui, -apple-system, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: max(16px, env(safe-area-inset-left));
+      padding-right: max(16px, env(safe-area-inset-right));
+      padding-top: max(20px, env(safe-area-inset-top));
+      padding-bottom: max(20px, env(safe-area-inset-bottom));
+      background: var(--bg);
+      color: var(--text-main);
+    }
+
+    .shell {
+      width: min(760px, 100%);
+      background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      box-shadow:
+        0 16px 60px rgba(0, 0, 0, 0.45),
+        0 0 1px rgba(255, 255, 255, 0.18);
+      padding: clamp(22px, 4vw, 34px);
+      backdrop-filter: blur(18px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .shell::before,
+    .shell::after {
+      content: "";
+      position: absolute;
+      width: 280px;
+      height: 280px;
+      border-radius: 50%;
+      filter: blur(90px);
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    .shell::before {
+      background: radial-gradient(circle, rgba(124, 58, 237, 0.5), rgba(15, 23, 42, 0));
+      top: -80px;
+      left: -60px;
+    }
+
+    .shell::after {
+      background: radial-gradient(circle, rgba(34, 211, 238, 0.5), rgba(15, 23, 42, 0));
+      bottom: -80px;
+      right: -60px;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 22px;
+    }
+
+    .badge {
+      padding: 8px 14px;
+      border-radius: 12px;
+      background: linear-gradient(120deg, var(--accent), var(--accent-2));
+      color: #0b0f1a;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      box-shadow: 0 12px 30px rgba(124, 58, 237, 0.35);
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(22px, 4vw, 30px);
+      letter-spacing: 0.06em;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+
+    .card {
+      position: relative;
+      background: var(--glass);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 18px 18px 20px;
+      overflow: hidden;
+    }
+
+    .card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(124, 58, 237, 0.08), rgba(34, 211, 238, 0.04));
+      pointer-events: none;
+    }
+
+    .card h2 {
+      margin: 0 0 12px;
+      font-size: 17px;
+      letter-spacing: 0.03em;
+    }
+
+    .input {
+      width: 100%;
+      padding: 14px 16px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text-main);
+      outline: none;
+      font-size: 16px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+      letter-spacing: 0.04em;
+    }
+
+    .input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.18);
+    }
+
+    .otp-value {
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: 10px;
+      margin: 6px 0 12px;
+      font-size: clamp(28px, 6vw, 38px);
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      color: #f8fafc;
+    }
+
+    .otp-box {
+      padding: 16px 12px;
+      text-align: center;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid var(--border);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      min-width: 42px;
+    }
+
+    .timer {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    .meta {
+      display: inline-flex;
+      gap: 10px;
+      align-items: center;
+      color: var(--muted);
+      font-size: 13px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .meta strong {
+      color: #e2e8f0;
+      letter-spacing: 0.02em;
+    }
+
+    .actions {
+      margin-top: 12px;
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .ghost-btn {
+      padding: 10px 14px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text-main);
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      transition: border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .ghost-btn:hover:not(:disabled) {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .ghost-btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .hint {
+      color: var(--muted);
+      font-size: 12px;
+      margin: 0;
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: max(12px, env(safe-area-inset-left));
+        padding-right: max(12px, env(safe-area-inset-right));
+        padding-top: max(16px, env(safe-area-inset-top));
+        padding-bottom: max(16px, env(safe-area-inset-bottom));
+      }
+
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+      }
+
+      .badge {
+        font-size: 13px;
+        padding: 8px 12px;
+      }
+
+      .card {
+        padding: 16px;
+      }
+
+      .input {
+        font-size: 15px;
+        padding: 12px 14px;
+      }
+
+      .otp-value {
+        gap: 8px;
+      }
+
+      .actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .ghost-btn {
+        width: 100%;
+        text-align: center;
+      }
+    }
+  </style>
+</head>
+  <body>
+    <div class="shell">
+      <header>
+        <span class="badge">OBJOPA 2FA</span>
+        <h1>Offline Authenticator</h1>
+      </header>
+
+      <div class="grid">
+        <div class="card">
+          <h2>Base32 секрет</h2>
+        <input
+          id="secret"
+          class="input"
+          placeholder="Например: JBSWY3DPEHPK3PXP"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
+
+        <div class="card">
+          <h2>Код</h2>
+          <div class="otp-value" id="otp"></div>
+          <div class="timer" id="remaining">30s</div>
+        </div>
+
+        <div class="card">
+          <h2>UNIX штамп</h2>
+          <div class="meta">Локально: <strong id="unix">-</strong></div>
+          <div class="meta">Глобально: <strong id="unix-global">—</strong></div>
+          <div class="meta">Сдвиг: <strong id="drift">—</strong></div>
+          <div class="actions">
+            <button class="ghost-btn" id="sync" type="button">Сравнить время</button>
+            <p class="hint" id="sync-hint">Запрос по сети только по кнопке.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <script>
+    const secretInput = document.getElementById("secret");
+    const otpTag = document.getElementById("otp");
+    const remainingTag = document.getElementById("remaining");
+    const unixTag = document.getElementById("unix");
+    const unixGlobalTag = document.getElementById("unix-global");
+    const driftTag = document.getElementById("drift");
+    const syncBtn = document.getElementById("sync");
+    const syncHint = document.getElementById("sync-hint");
+
+    let cryptoKey = null;
+    let lastSecret = "";
+    let isUpdating = false;
+    let lastLocalUnix = null;
+
+    function extractSecretFromUrl() {
+      const params = new URLSearchParams(window.location.search);
+      const querySecret = params.get("secret");
+      const segments = window.location.pathname.split("/").filter(Boolean);
+      const lastSegment = segments[segments.length - 1];
+      const candidates = [querySecret];
+
+      if (lastSegment && !lastSegment.toLowerCase().endsWith("index.html")) {
+        candidates.push(lastSegment);
+      }
+
+      for (const candidate of candidates) {
+        if (!candidate) continue;
+        const normalized = decodeURIComponent(candidate)
+          .replace(/[^a-zA-Z2-7\s]/g, "")
+          .toUpperCase();
+        if (normalized.trim()) return normalized;
+      }
+
+      return null;
+    }
+
+    function base32ToBytes(secret) {
+      const cleaned = secret.replace(/\s+/g, "").toUpperCase();
+      const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+      let bits = "";
+      for (const char of cleaned) {
+        const idx = alphabet.indexOf(char);
+        if (idx === -1) {
+          throw new Error(`Недопустимый символ: ${char}`);
+        }
+        bits += idx.toString(2).padStart(5, "0");
+      }
+      const bytes = [];
+      for (let i = 0; i + 8 <= bits.length; i += 8) {
+        bytes.push(parseInt(bits.slice(i, i + 8), 2));
+      }
+      return new Uint8Array(bytes);
+    }
+
+    async function prepareKey(secret) {
+      if (!secret.trim()) {
+        cryptoKey = null;
+        lastSecret = "";
+        return;
+      }
+      try {
+        const bytes = base32ToBytes(secret);
+        if (!bytes.length) {
+          throw new Error("Секрет пустой после декодирования");
+        }
+        cryptoKey = await crypto.subtle.importKey(
+          "raw",
+          bytes,
+          { name: "HMAC", hash: "SHA-1" },
+          false,
+          ["sign"]
+        );
+        lastSecret = secret;
+      } catch (error) {
+        cryptoKey = null;
+        lastSecret = "";
+      }
+    }
+
+    async function generateOtp(unixTime) {
+      if (!cryptoKey) return null;
+      const timeStep = 30;
+      const counter = Math.floor(unixTime / timeStep);
+      const counterBytes = new ArrayBuffer(8);
+      const view = new DataView(counterBytes);
+      view.setUint32(4, counter, false);
+      const signature = await crypto.subtle.sign("HMAC", cryptoKey, counterBytes);
+      const hash = new Uint8Array(signature);
+      const offset = hash[hash.length - 1] & 0x0f;
+      const binary =
+        ((hash[offset] & 0x7f) << 24) |
+        ((hash[offset + 1] & 0xff) << 16) |
+        ((hash[offset + 2] & 0xff) << 8) |
+        (hash[offset + 3] & 0xff);
+      const otp = (binary % 1_000_000).toString().padStart(6, "0");
+      return otp;
+    }
+
+    async function update() {
+      if (isUpdating) return;
+      isUpdating = true;
+      const unixTime = Math.floor(Date.now() / 1000);
+      lastLocalUnix = unixTime;
+      unixTag.textContent = unixTime;
+      const secondsLeft = 30 - (unixTime % 30);
+      remainingTag.textContent = `${secondsLeft}s`;
+
+      if (!cryptoKey) {
+        renderOtp("------");
+        isUpdating = false;
+        return;
+      }
+
+      try {
+        const otp = await generateOtp(unixTime);
+        renderOtp(otp ?? "------");
+      } catch (error) {
+        renderOtp("------");
+      } finally {
+        isUpdating = false;
+      }
+    }
+
+    function renderOtp(value) {
+      const digits = value.padStart(6, "-").slice(0, 6).split("");
+      otpTag.innerHTML = digits
+        .map((digit) => `<span class="otp-box">${digit}</span>`)
+        .join("");
+    }
+
+    secretInput.addEventListener("input", (event) => {
+      const value = event.target.value
+        .replace(/[^a-zA-Z2-7\s]/g, "")
+        .toUpperCase();
+      event.target.value = value;
+      if (value === lastSecret) return;
+      prepareKey(value).then(update);
+    });
+
+    const initialSecret = extractSecretFromUrl();
+    if (initialSecret) {
+      secretInput.value = initialSecret;
+      prepareKey(initialSecret).then(update);
+    }
+
+    async function fetchNetworkTime() {
+      syncBtn.disabled = true;
+      syncBtn.textContent = "Запрос...";
+      syncHint.textContent = "Пробуем получить сетевое время";
+      try {
+        const response = await fetch("https://worldtimeapi.org/api/ip", {
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error(`Статус ${response.status}`);
+        }
+        const data = await response.json();
+        const networkUnix = Math.floor(data.unixtime);
+        unixGlobalTag.textContent = networkUnix;
+        const currentLocal = lastLocalUnix ?? Math.floor(Date.now() / 1000);
+        const drift = currentLocal - networkUnix;
+        const signed = drift > 0 ? `+${drift}` : `${drift}`;
+        driftTag.textContent = `${signed} сек`;
+        syncHint.textContent = "Сравнение завершено.";
+      } catch (error) {
+        syncHint.textContent = "Не удалось получить время.";
+        driftTag.textContent = "—";
+        unixGlobalTag.textContent = "—";
+      } finally {
+        syncBtn.disabled = false;
+        syncBtn.textContent = "Сравнить время";
+      }
+    }
+
+    syncBtn.addEventListener("click", fetchNetworkTime);
+
+    setInterval(update, 1000);
+    renderOtp("------");
+    update();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add URL parsing to prefill the secret from path segments or `secret` query parameter for quick sharing
- keep normalization for Base32 characters before initializing the authenticator

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e28e063083319dbcf9c0fc397f77)