### PR TITLE
Replace Instagram downloader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi[standard]>=0.118.0",
     "gallery-dl>=1.30.8",
     "google-genai>=1.39.1",
+    "httpcloak>=1.6.7",
     "httpx>=0.28.1",
     "instaloader>=4.14.2",
     "loguru>=0.7.3",

--- a/tg_bot/downloaders/downloader_manager.py
+++ b/tg_bot/downloaders/downloader_manager.py
@@ -3,6 +3,7 @@
 Приоритет: кастомные версии -> yt-dlp -> gallery-dl
 """
 
+import re
 import traceback
 from dataclasses import dataclass
 from enum import Enum
@@ -10,6 +11,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from core.logger import logger
+from tg_bot.utils.cookies_manager import cookies_manager
 
 from .gallery_dl import download_with_gallery_dl
 from .instagram import INSTAGRAM_REGEX, download_instagram_media
@@ -77,29 +79,30 @@ class DownloaderManager:
         # Проверяем, является ли URL кастомной платформой
         is_instagram = INSTAGRAM_REGEX.match(url)
         is_custom_platform = is_instagram or TWITTER_REGEX.match(url)
-
-        # Проиритет для кукисов, если это инстаграмм
-        if use_cookies and is_instagram:
-            cookies_yt_dlp_result = await self._try_ytdlp(url, use_cookies=True)
-            if cookies_yt_dlp_result.success:
-                return cookies_yt_dlp_result
+        instagram_use_cookies = use_cookies or (bool(is_instagram) and await self._has_saved_cookies("instagram"))
+        effective_use_cookies = instagram_use_cookies if is_instagram else use_cookies
 
         # Попытка 1: Кастомные скачиватели
-        custom_result = await self._try_custom_downloaders(url)
+        custom_result = await self._try_custom_downloaders(url, use_cookies=effective_use_cookies)
         if custom_result.success:
             return custom_result
 
         if is_instagram:
-            ytdlp_result = await self._try_ytdlp(url, use_cookies=True)
+            ytdlp_result = await self._try_ytdlp(url, use_cookies=effective_use_cookies)
             if ytdlp_result.success:
                 return ytdlp_result
 
-            gallery_result = await self._try_gallery_dl(url, use_cookies=True)
+            gallery_result = await self._try_gallery_dl(url, use_cookies=effective_use_cookies)
             if gallery_result.success:
                 return gallery_result
 
-            attempts_summary = "\n".join(self.download_attempts)
-            return DownloadResult(success=False, files=[], caption=None, error=attempts_summary, downloader_used=None)
+            return DownloadResult(
+                success=False,
+                files=[],
+                caption=None,
+                error=self._instagram_error_message(use_cookies=effective_use_cookies),
+                downloader_used=None,
+            )
 
         # Если это кастомная платформа и она не сработала - не пробуем другие методы
         if is_custom_platform:
@@ -122,12 +125,12 @@ class DownloaderManager:
 
         return DownloadResult(success=False, files=[], caption=None, error=error_message, downloader_used=None)
 
-    async def _try_custom_downloaders(self, url: str) -> DownloadResult:
+    async def _try_custom_downloaders(self, url: str, use_cookies: bool = False) -> DownloadResult:
         """Пробует кастомные скачиватели."""
         try:
             if INSTAGRAM_REGEX.match(url):
                 logger.info(f"Attempting Instagram download for: {url}")
-                shortcode, error = await download_instagram_media(url)
+                shortcode, error = await download_instagram_media(url, use_cookies=use_cookies)
 
                 if shortcode and not error:
                     from core.config import DOWNLOADS_DIR
@@ -222,7 +225,7 @@ class DownloaderManager:
 
         except Exception as e:
             logger.error(f"Custom downloader error: {e}\n{traceback.format_exc()}")
-            self.download_attempts.append(f"Custom: Exception - {str(e)}")
+            self.download_attempts.append(f"Custom: Exception - {self._clean_error_text(str(e))}")
 
         return DownloadResult(
             success=False,
@@ -231,6 +234,15 @@ class DownloaderManager:
             error="\n".join(self.download_attempts),
             downloader_used=None,
         )
+
+    async def _has_saved_cookies(self, site_name: str) -> bool:
+        try:
+            available_cookies = await cookies_manager.list_available_cookies()
+        except Exception as e:
+            logger.debug(f"Saved cookies check failed for {site_name}: {e}")
+            return False
+
+        return site_name.lower() in available_cookies
 
     async def _try_ytdlp(self, url: str, use_cookies: bool = False) -> DownloadResult:
         """Пробует yt-dlp. Если use_cookies=True, сначала пробует с cookies."""
@@ -273,6 +285,7 @@ class DownloaderManager:
 
     def _filter_ytdlp_error(self, error: str) -> str:
         """Фильтрует и упрощает ошибки yt-dlp для пользователя."""
+        error = self._clean_error_text(error)
         error_lower = error.lower()
 
         # Распространенные ошибки и их упрощенные версии
@@ -297,6 +310,33 @@ class DownloaderManager:
         else:
             # Если ошибка не распознана, возвращаем укороченную версию
             return error[:100] + "..." if len(error) > 100 else error
+
+    def _instagram_error_message(self, use_cookies: bool) -> str:
+        attempts_summary = "\n".join(self.download_attempts)
+        attempts_lower = attempts_summary.lower()
+        auth_markers = (
+            "accounts/login",
+            "login page",
+            "login required",
+            "requires login",
+            "use --cookies",
+            "empty media response",
+            "unauthorized",
+            "require_login",
+        )
+
+        if any(marker in attempts_lower for marker in auth_markers):
+            if use_cookies:
+                return (
+                    "Instagram: ❌ Cookies не сработали или Instagram временно ограничил доступ. "
+                    "Обнови cookies через /set_cookies и повтори /d <url>."
+                )
+            return (
+                "Instagram: ❌ Instagram не отдал медиа без авторизации. "
+                "Загрузи cookies через /set_cookies и повтори /d <url>."
+            )
+
+        return attempts_summary
 
     async def _try_gallery_dl(self, url: str, use_cookies: bool = False) -> DownloadResult:
         """Пробует gallery-dl."""
@@ -330,6 +370,7 @@ class DownloaderManager:
 
     def _filter_gallery_dl_error(self, error: str) -> str:
         """Фильтрует и упрощает ошибки gallery-dl для пользователя."""
+        error = self._clean_error_text(error)
         error_lower = error.lower()
 
         # Распространенные ошибки gallery-dl
@@ -362,6 +403,11 @@ class DownloaderManager:
         else:
             # Если ошибка не распознана, возвращаем укороченную версию
             return error[:100] + "..." if len(error) > 100 else error
+
+    @staticmethod
+    def _clean_error_text(error: str) -> str:
+        error = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", error)
+        return " ".join(error.split())
 
 
 # Создаем глобальный экземпляр менеджера

--- a/tg_bot/downloaders/downloader_manager.py
+++ b/tg_bot/downloaders/downloader_manager.py
@@ -51,8 +51,8 @@ class DownloaderManager:
 
         Порядок попыток:
         1. Кастомные скачиватели (Instagram, Twitter) - строгий режим
-        2. yt-dlp (для видео контента) - только если не кастомная платформа
-        3. gallery-dl (для изображений) - только если не кастомная платформа
+        2. yt-dlp (для видео контента)
+        3. gallery-dl (для изображений)
         """
         return await self._download_media_impl(url, use_cookies=False)
 
@@ -69,16 +69,17 @@ class DownloaderManager:
 
         Порядок попыток:
         1. Кастомные скачиватели (Instagram, Twitter) - строгий режим
-        2. yt-dlp (для видео контента) - только если не кастомная платформа
-        3. gallery-dl (для изображений) - только если не кастомная платформа
+        2. yt-dlp (для видео контента)
+        3. gallery-dl (для изображений)
         """
         self.download_attempts = []
 
         # Проверяем, является ли URL кастомной платформой
-        is_custom_platform = INSTAGRAM_REGEX.match(url) or TWITTER_REGEX.match(url)
+        is_instagram = INSTAGRAM_REGEX.match(url)
+        is_custom_platform = is_instagram or TWITTER_REGEX.match(url)
 
         # Проиритет для кукисов, если это инстаграмм
-        if use_cookies and INSTAGRAM_REGEX.match(url):
+        if use_cookies and is_instagram:
             cookies_yt_dlp_result = await self._try_ytdlp(url, use_cookies=True)
             if cookies_yt_dlp_result.success:
                 return cookies_yt_dlp_result
@@ -88,18 +89,30 @@ class DownloaderManager:
         if custom_result.success:
             return custom_result
 
+        if is_instagram:
+            ytdlp_result = await self._try_ytdlp(url, use_cookies=True)
+            if ytdlp_result.success:
+                return ytdlp_result
+
+            gallery_result = await self._try_gallery_dl(url, use_cookies=True)
+            if gallery_result.success:
+                return gallery_result
+
+            attempts_summary = "\n".join(self.download_attempts)
+            return DownloadResult(success=False, files=[], caption=None, error=attempts_summary, downloader_used=None)
+
         # Если это кастомная платформа и она не сработала - не пробуем другие методы
         if is_custom_platform:
             logger.warning(f"Custom platform failed for {url}, not trying other methods - {custom_result}")
             return custom_result  # Возвращаем ошибку кастомного скачивателя
 
-        # Попытка 2: yt-dlp для видео контента (только для не-кастомных платформ)
+        # Попытка 2: yt-dlp для видео контента
         ytdlp_result = await self._try_ytdlp(url, use_cookies=use_cookies)
         if ytdlp_result.success:
             return ytdlp_result
 
-        # Попытка 3: gallery-dl для изображений (только для не-кастомных платформ)
-        gallery_result = await self._try_gallery_dl(url)
+        # Попытка 3: gallery-dl для изображений
+        gallery_result = await self._try_gallery_dl(url, use_cookies=use_cookies)
         if gallery_result.success:
             return gallery_result
 
@@ -285,11 +298,11 @@ class DownloaderManager:
             # Если ошибка не распознана, возвращаем укороченную версию
             return error[:100] + "..." if len(error) > 100 else error
 
-    async def _try_gallery_dl(self, url: str) -> DownloadResult:
+    async def _try_gallery_dl(self, url: str, use_cookies: bool = False) -> DownloadResult:
         """Пробует gallery-dl."""
         try:
-            logger.info(f"Attempting gallery-dl download for: {url}")
-            files, caption, error = await download_with_gallery_dl(url)
+            logger.info(f"Attempting gallery-dl download for: {url} (use_cookies={use_cookies})")
+            files, caption, error = await download_with_gallery_dl(url, use_cookies=use_cookies)
 
             if files:
                 self.download_attempts.append("gallery-dl: Success")

--- a/tg_bot/downloaders/gallery_dl.py
+++ b/tg_bot/downloaders/gallery_dl.py
@@ -29,8 +29,7 @@ async def download_with_gallery_dl(
         site_name = cookies_manager.get_site_name(url)
         cookies_path = await cookies_manager.get_cookies(site_name)
 
-    def _download() -> None:
-        nonlocal title
+    def _download() -> subprocess.CompletedProcess[str]:
         cmd = [
             sys.executable,
             "-m",
@@ -41,21 +40,26 @@ async def download_with_gallery_dl(
         if cookies_path:
             cmd.extend(("--cookies", str(cookies_path)))
         cmd.append(url)
-        subprocess.run(cmd, check=False)
+        return subprocess.run(cmd, check=False, capture_output=True, text=True, encoding="utf-8", errors="replace")
 
     try:
         loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, _download)
-        for p in tmp.iterdir():
-            if p.is_file():
-                dest = download_path / p.name
-                shutil.move(str(p), dest)
-                files.append(dest)
-        tmp.rmdir()
+        result = await loop.run_in_executor(None, _download)
+        for p in sorted((p for p in tmp.rglob("*") if p.is_file()), key=lambda path: str(path)):
+            dest = download_path / p.name
+            if dest.exists():
+                dest = download_path / f"{p.stem}_{secrets.token_hex(4)}{p.suffix}"
+            shutil.move(str(p), dest)
+            files.append(dest)
+
+        if not files:
+            output = "\n".join(part.strip() for part in (result.stderr, result.stdout) if part and part.strip())
+            error = output or f"gallery-dl exited with code {result.returncode}"
     except Exception as e:  # noqa: BLE001
         logger.error(f"gallery-dl download error: {e}")
         error = str(e)
     finally:
+        shutil.rmtree(tmp, ignore_errors=True)
         if cookies_path and cookies_path.exists():
             cookies_path.unlink(missing_ok=True)
 

--- a/tg_bot/downloaders/gallery_dl.py
+++ b/tg_bot/downloaders/gallery_dl.py
@@ -2,15 +2,17 @@ import asyncio
 import secrets
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Tuple
 
 from core.config import DOWNLOADS_DIR
 from core.logger import logger
+from tg_bot.utils.cookies_manager import cookies_manager
 
 
 async def download_with_gallery_dl(
-    url: str, download_path: Path = DOWNLOADS_DIR
+    url: str, download_path: Path = DOWNLOADS_DIR, use_cookies: bool = False
 ) -> Tuple[List[Path], str | None, str | None]:
     """Download media using gallery-dl and return file paths, title and error."""
     download_path.mkdir(exist_ok=True)
@@ -18,18 +20,27 @@ async def download_with_gallery_dl(
     files: List[Path] = []
     title: str | None = None
     error: str | None = None
+    cookies_path: Path | None = None
 
     tmp = download_path / f"gdl_{secrets.token_hex(8)}"
     tmp.mkdir()
 
+    if use_cookies:
+        site_name = cookies_manager.get_site_name(url)
+        cookies_path = await cookies_manager.get_cookies(site_name)
+
     def _download() -> None:
         nonlocal title
         cmd = [
-            "gallery-dl",
+            sys.executable,
+            "-m",
+            "gallery_dl",
             "-D",
             str(tmp),
-            url,
         ]
+        if cookies_path:
+            cmd.extend(("--cookies", str(cookies_path)))
+        cmd.append(url)
         subprocess.run(cmd, check=False)
 
     try:
@@ -44,5 +55,8 @@ async def download_with_gallery_dl(
     except Exception as e:  # noqa: BLE001
         logger.error(f"gallery-dl download error: {e}")
         error = str(e)
+    finally:
+        if cookies_path and cookies_path.exists():
+            cookies_path.unlink(missing_ok=True)
 
     return files, title, error

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -111,11 +111,20 @@ class InstagramWebDownloader:
         except InstagramDownloadError as exc:
             logger.debug(f"Instagram HTML page failed for {shortcode}: {exc}")
 
+        raw_video_post: InstagramPost | None = None
         if html_text:
+            raw_video_post = self._post_from_raw_video_urls(html_text, shortcode, canonical_url)
             json_candidates = self._extract_json_candidates(html_text)
             for candidate in json_candidates:
                 post = self._post_from_json(candidate, shortcode, canonical_url)
                 if post.media:
+                    if (
+                        "/reel/" in canonical_url
+                        and raw_video_post.media
+                        and not any(media.is_video for media in post.media)
+                    ):
+                        logger.debug(f"Using raw Instagram video URL fallback for reel {shortcode}")
+                        return raw_video_post
                     return post
 
         json_candidates = await self._load_json_candidates(session, shortcode, canonical_url)
@@ -123,6 +132,10 @@ class InstagramWebDownloader:
             post = self._post_from_json(candidate, shortcode, canonical_url)
             if post.media:
                 return post
+
+        if raw_video_post and raw_video_post.media:
+            logger.debug(f"Using raw Instagram video URL fallback for {shortcode}")
+            return raw_video_post
 
         if html_text:
             post = self._post_from_meta_tags(html_text, shortcode, canonical_url)
@@ -493,6 +506,31 @@ class InstagramWebDownloader:
 
         return None
 
+    def _post_from_raw_video_urls(self, html_text: str, shortcode: str, canonical_url: str) -> InstagramPost:
+        media_items: list[InstagramMedia] = []
+
+        patterns = (
+            r'"video_url"\s*:\s*"([^"]+)"',
+            r'\\"video_url\\"\s*:\s*\\"(.+?)\\"',
+            r'"playback_url"\s*:\s*"([^"]+)"',
+            r'\\"playback_url\\"\s*:\s*\\"(.+?)\\"',
+            r'https?:\\?/\\?/[^"\'<>]+?\.mp4[^"\'<>]*',
+        )
+
+        for pattern in patterns:
+            for match in re.finditer(pattern, html_text, flags=re.IGNORECASE):
+                raw_url = match.group(1) if match.groups() else match.group(0)
+                video_url = self._decode_media_url(raw_url)
+                if self._looks_like_video_url(video_url):
+                    media_items.append(InstagramMedia(url=video_url, is_video=True, index=len(media_items) + 1))
+
+        return InstagramPost(
+            shortcode=shortcode,
+            canonical_url=canonical_url,
+            caption=None,
+            media=self._dedupe_media(media_items),
+        )
+
     def _post_from_meta_tags(self, html_text: str, shortcode: str, canonical_url: str) -> InstagramPost:
         media: list[InstagramMedia] = []
         caption: str | None = None
@@ -555,6 +593,26 @@ class InstagramWebDownloader:
         return value_lower.startswith("http") and any(
             marker in value_lower for marker in ("cdninstagram", "fbcdn", ".cdn", "scontent")
         )
+
+    def _looks_like_video_url(self, value: str) -> bool:
+        value_lower = value.lower()
+        return self._looks_like_media_url(value) and ".mp4" in value_lower
+
+    def _decode_media_url(self, value: str) -> str:
+        decoded = html.unescape(value)
+
+        for _ in range(3):
+            previous = decoded
+            try:
+                decoded = json.loads(f'"{decoded}"')
+            except json.JSONDecodeError:
+                decoded = decoded.replace("\\/", "/").replace("\\u0026", "&").replace("\\u003d", "=")
+
+            decoded = html.unescape(decoded)
+            if decoded == previous:
+                break
+
+        return decoded
 
     def _try_load_json(self, text: str) -> Any | None:
         if not text:

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -183,10 +183,10 @@ class InstagramWebDownloader:
         self.user_agent = user_agent
         self.http_preset = http_preset
 
-    async def download(self, url: str, download_path: Path = DOWNLOADS_DIR) -> InstagramPost:
+    async def download(self, url: str, download_path: Path = DOWNLOADS_DIR, use_cookies: bool = False) -> InstagramPost:
         download_path.mkdir(parents=True, exist_ok=True)
 
-        cookies_path = await self._get_saved_instagram_cookies()
+        cookies_path = await self._get_saved_instagram_cookies() if use_cookies else None
         try:
             async with InstagramHttpSession(self.http_preset) as session:
                 if cookies_path:
@@ -250,7 +250,7 @@ class InstagramWebDownloader:
             raw_video_post = self._post_from_raw_video_urls(html_text, shortcode, canonical_url)
             json_candidates = self._extract_json_candidates(html_text)
             for candidate in json_candidates:
-                post = self._post_from_json(candidate, shortcode, canonical_url)
+                post = self._safe_post_from_json(candidate, shortcode, canonical_url)
                 if post.media:
                     if is_reel and any(media.is_video for media in post.media):
                         return post
@@ -264,7 +264,7 @@ class InstagramWebDownloader:
 
         json_candidates = await self._load_json_candidates(session, shortcode, canonical_url)
         for candidate in json_candidates:
-            post = self._post_from_json(candidate, shortcode, canonical_url)
+            post = self._safe_post_from_json(candidate, shortcode, canonical_url)
             if post.media:
                 if is_reel and not any(media.is_video for media in post.media):
                     logger.debug(f"Ignoring image-only Instagram reel API metadata for {shortcode}")
@@ -286,6 +286,13 @@ class InstagramWebDownloader:
                 return post
 
         raise InstagramNoMediaError("No media metadata found on Instagram page.")
+
+    def _safe_post_from_json(self, data: Any, shortcode: str, canonical_url: str) -> InstagramPost:
+        try:
+            return self._post_from_json(data, shortcode, canonical_url)
+        except (AttributeError, KeyError, TypeError, ValueError, IndexError) as exc:
+            logger.debug(f"Skipping malformed Instagram JSON candidate for {shortcode}: {exc}")
+            return InstagramPost(shortcode=shortcode, canonical_url=canonical_url, caption=None, media=[])
 
     async def _load_json_candidates(
         self, session: InstagramHttpSession, shortcode: str, canonical_url: str
@@ -515,7 +522,8 @@ class InstagramWebDownloader:
         return None
 
     def _pick_image_url(self, node: dict[str, Any]) -> str | None:
-        image_versions = (node.get("image_versions2") or {}).get("candidates")
+        image_versions2 = node.get("image_versions2")
+        image_versions = image_versions2.get("candidates") if isinstance(image_versions2, dict) else None
         if isinstance(image_versions, list):
             candidate = self._pick_best_candidate_url(image_versions)
             if candidate:
@@ -864,11 +872,11 @@ async def reset_instaloader_session() -> None:
     logger.info("Instagram downloader cache reset")
 
 
-async def download_instagram_media(url: str) -> tuple[str | None, str | None]:
+async def download_instagram_media(url: str, use_cookies: bool = False) -> tuple[str | None, str | None]:
     """Download Instagram post media and return shortcode plus a user-facing error."""
     try:
         client = await get_instaloader_session()
-        post = await client.download(url, DOWNLOADS_DIR)
+        post = await client.download(url, DOWNLOADS_DIR, use_cookies=use_cookies)
         return post.shortcode, None
     except InstagramUnsupportedUrlError as exc:
         return None, f"❌ Ошибка: {exc}"
@@ -884,7 +892,7 @@ async def download_instagram_media(url: str) -> tuple[str | None, str | None]:
         return None, f"❌ Ошибка Instagram: {exc}"
     except Exception as exc:
         logger.exception(f"Unexpected Instagram downloader error: {exc}")
-        return None, f"❌ Ошибка: {exc}"
+        return None, "❌ Ошибка: Instagram вернул неожиданный формат ответа."
 
 
 DOWNLOADS_DIR.mkdir(exist_ok=True)

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -1,19 +1,23 @@
 import asyncio
 import html
 import json
+import os
 import re
 import secrets
 import shutil
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from curl_cffi.requests import AsyncSession, Response
+import httpcloak
+from yt_dlp import YoutubeDL
 
-from core.config import DOWNLOADS_DIR
+from core.config import DOWNLOADS_DIR, INSTAGRAM_PASSWORD, INSTAGRAM_USERNAME
 from core.logger import logger
-from tg_bot.services.instagram_ua_service import InstagramUserAgentService, instagram_ua_service
+from tg_bot.utils.cookies_manager import cookies_manager
 
 INSTAGRAM_REGEX = re.compile(
     r"(https?:\/\/(?:www\.)?instagram\.com\/(?:(?:p|reel|tv)\/[\w\-]+|share\/(?:p\/|reel\/|tv\/)?[\w\-]+|stories\/[\w.\-]+(?:\/\d+)?))"
@@ -22,6 +26,22 @@ INSTAGRAM_REGEX = re.compile(
 INSTAGRAM_APP_ID = "936619743392459"
 REQUEST_TIMEOUT = 20
 SHORTCODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+VIDEO_EXTENSIONS = (".mp4", ".mov", ".mkv", ".webm")
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
+FALLBACK_MEDIA_EXTENSIONS = VIDEO_EXTENSIONS + IMAGE_EXTENSIONS
+FALLBACK_RETRIES = 3
+CHROME_149_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+)
+HTTPCLOAK_DEFAULT_PRESET = "chrome-149-windows"
+HTTPCLOAK_CUSTOM_PRESET_NAME = "instagram-chrome149"
+HTTPCLOAK_FALLBACK_PRESET = "chrome-latest"
+HTTPCLOAK_USER_AGENT_ENV = "INSTAGRAM_HTTPCLOAK_USER_AGENT"
+HTTPCLOAK_PRESET_ENV = "INSTAGRAM_HTTPCLOAK_PRESET"
+HTTPCLOAK_PRESET_JSON_ENV = "INSTAGRAM_HTTPCLOAK_PRESET_JSON"
+HTTPCLOAK_PRESET_FILE_ENV = "INSTAGRAM_HTTPCLOAK_PRESET_FILE"
+HTTPCLOAK_JA3_ENV = "INSTAGRAM_HTTPCLOAK_JA3"
+HTTPCLOAK_AKAMAI_ENV = "INSTAGRAM_HTTPCLOAK_AKAMAI"
 
 
 class InstagramDownloadError(Exception):
@@ -59,33 +79,489 @@ class InstagramPost:
     media: list[InstagramMedia]
 
 
+@dataclass(slots=True)
+class InstagramHttpResponse:
+    status_code: int
+    url: str
+    text: str
+    content: bytes
+    headers: dict[str, str]
+
+
+class InstagramHttpSession:
+    def __init__(self, preset: str):
+        self._session = httpcloak.Session(
+            preset=preset,
+            timeout=REQUEST_TIMEOUT,
+            retry=FALLBACK_RETRIES,
+            prefer_ipv4=True,
+            http_version="auto",
+        )
+
+    async def __aenter__(self) -> "InstagramHttpSession":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+    async def get(
+        self,
+        url: str,
+        *,
+        allow_redirects: bool = True,
+        headers: dict[str, str] | None = None,
+    ) -> InstagramHttpResponse:
+        request_headers = headers or {}
+        try:
+            response = await self._session.get_async(url, headers=request_headers, allow_redirects=allow_redirects)
+        except TypeError:
+            response = await self._session.get_async(url, headers=request_headers)
+        return self._normalize_response(response)
+
+    def close(self) -> None:
+        self._session.close()
+
+    def load_netscape_cookies(self, cookies_path: Path) -> None:
+        try:
+            lines = cookies_path.read_text(encoding="utf-8").splitlines()
+        except Exception as exc:
+            logger.warning(f"Failed to read Instagram cookies for HTTPCloak session: {exc}")
+            return
+
+        for line in lines:
+            if not line.strip() or (line.startswith("#") and not line.startswith("#HttpOnly_")):
+                continue
+
+            http_only = line.startswith("#HttpOnly_")
+            if http_only:
+                line = line.removeprefix("#HttpOnly_")
+
+            parts = line.split("\t")
+            if len(parts) < 7:
+                continue
+
+            domain, _, path, secure, _, name, value = parts[:7]
+            try:
+                self._session.set_cookie(
+                    name,
+                    value,
+                    domain=domain,
+                    path=path or "/",
+                    secure=secure.upper() == "TRUE",
+                    http_only=http_only,
+                )
+            except Exception as exc:
+                logger.debug(f"Failed to load Instagram cookie {name!r} into HTTPCloak session: {exc}")
+
+    def _normalize_response(self, response: Any) -> InstagramHttpResponse:
+        return InstagramHttpResponse(
+            status_code=int(response.status_code),
+            url=str(response.url),
+            text=str(response.text),
+            content=bytes(response.content),
+            headers=self._normalize_headers(getattr(response, "headers", {}) or {}),
+        )
+
+    def _normalize_headers(self, headers: Any) -> dict[str, str]:
+        normalized: dict[str, str] = {}
+        for key, value in dict(headers).items():
+            if isinstance(value, list):
+                normalized[key.lower()] = value[-1] if value else ""
+            else:
+                normalized[key.lower()] = str(value)
+        return normalized
+
+
+class QuietYtdlpLogger:
+    def debug(self, message: str) -> None:
+        pass
+
+    def warning(self, message: str) -> None:
+        logger.debug(f"yt-dlp warning: {message}")
+
+    def error(self, message: str) -> None:
+        logger.debug(f"yt-dlp error: {message}")
+
+
+_httpcloak_preset_name: str | None = None
+
+
+def get_httpcloak_preset_name() -> str:
+    global _httpcloak_preset_name
+    if _httpcloak_preset_name:
+        return _httpcloak_preset_name
+
+    custom_preset = _load_custom_httpcloak_preset()
+    if custom_preset:
+        _httpcloak_preset_name = custom_preset
+        return custom_preset
+
+    requested_preset = os.getenv(HTTPCLOAK_PRESET_ENV, HTTPCLOAK_DEFAULT_PRESET).strip() or HTTPCLOAK_DEFAULT_PRESET
+    base_preset = _first_available_httpcloak_preset(requested_preset)
+    preset_name = _register_instagram_httpcloak_preset(base_preset)
+    _httpcloak_preset_name = preset_name
+    return preset_name
+
+
+def _load_custom_httpcloak_preset() -> str | None:
+    preset_json = os.getenv(HTTPCLOAK_PRESET_JSON_ENV)
+    preset_file = os.getenv(HTTPCLOAK_PRESET_FILE_ENV)
+
+    if preset_file:
+        try:
+            preset_json = Path(preset_file).read_text(encoding="utf-8")
+        except Exception as exc:
+            logger.warning(f"Failed to read Instagram HTTPCloak preset file: {exc}")
+
+    if not preset_json:
+        return None
+
+    return _load_httpcloak_preset_json(preset_json, HTTPCLOAK_CUSTOM_PRESET_NAME)
+
+
+def _first_available_httpcloak_preset(requested_preset: str) -> str:
+    try:
+        httpcloak.describe_preset(requested_preset)
+        return requested_preset
+    except Exception as exc:
+        logger.warning(
+            f"HTTPCloak preset {requested_preset!r} is not available ({exc}); using {HTTPCLOAK_FALLBACK_PRESET!r}"
+        )
+        return HTTPCLOAK_FALLBACK_PRESET
+
+
+def _register_instagram_httpcloak_preset(base_preset: str) -> str:
+    try:
+        preset_json = httpcloak.describe_preset(base_preset)
+    except Exception as exc:
+        logger.warning(f"Failed to describe HTTPCloak preset {base_preset!r}: {exc}; using preset directly")
+        return base_preset
+
+    return _load_httpcloak_preset_json(preset_json, HTTPCLOAK_CUSTOM_PRESET_NAME, force_name=True)
+
+
+def _load_httpcloak_preset_json(preset_json: str, fallback_name: str, *, force_name: bool = False) -> str:
+    spec = json.loads(preset_json)
+    preset = spec.setdefault("preset", {})
+    preset_name = fallback_name if force_name else str(preset.get("name") or fallback_name)
+    preset["name"] = preset_name
+
+    ja3 = os.getenv(HTTPCLOAK_JA3_ENV)
+    if ja3:
+        preset["tls"] = {"ja3": ja3}
+
+    akamai = os.getenv(HTTPCLOAK_AKAMAI_ENV)
+    if akamai:
+        http2 = preset.setdefault("http2", {})
+        http2["akamai"] = akamai
+
+    serialized = json.dumps(spec)
+    try:
+        httpcloak.load_preset_from_json(serialized)
+    except Exception as exc:
+        if "already" not in str(exc).lower() and "exist" not in str(exc).lower():
+            raise
+
+    return preset_name
+
+
 class InstagramWebDownloader:
     """Small Instagram web downloader that does not depend on Instaloader."""
 
-    def __init__(self, user_agent: str):
+    def __init__(self, user_agent: str, http_preset: str):
         self.user_agent = user_agent
+        self.http_preset = http_preset
 
     async def download(self, url: str, download_path: Path = DOWNLOADS_DIR) -> InstagramPost:
         download_path.mkdir(parents=True, exist_ok=True)
 
-        async with AsyncSession() as session:
-            shortcode, canonical_url = await self._resolve_shortcode(session, url)
-            post = await self._load_post(session, shortcode, canonical_url)
+        cookies_path = await self._get_saved_instagram_cookies()
+        try:
+            async with InstagramHttpSession(self.http_preset) as session:
+                if cookies_path:
+                    session.load_netscape_cookies(cookies_path)
 
-            if not post.media:
-                raise InstagramNoMediaError("Instagram did not expose downloadable media for this post.")
+                shortcode, canonical_url = await self._resolve_shortcode(session, url)
+                try:
+                    post = await self._load_post(session, shortcode, canonical_url)
+                except (InstagramAuthRequiredError, InstagramNoMediaError) as exc:
+                    fallback_post = await self._download_authenticated_fallback(canonical_url, shortcode, download_path)
+                    if fallback_post:
+                        return fallback_post
+                    raise exc
 
-            self._cleanup_old_files(download_path, shortcode)
-            downloaded_files = await self._download_media_files(session, post, download_path)
-            if not downloaded_files:
-                raise InstagramNoMediaError("Instagram media links were found, but files were not downloaded.")
+                if not post.media:
+                    raise InstagramNoMediaError("Instagram did not expose downloadable media for this post.")
 
-            if post.caption:
-                (download_path / f"{shortcode}.txt").write_text(post.caption, encoding="utf-8")
+                self._cleanup_old_files(download_path, shortcode)
+                downloaded_files = await self._download_media_files(session, post, download_path)
+                if not downloaded_files:
+                    raise InstagramNoMediaError("Instagram media links were found, but files were not downloaded.")
 
-            return post
+                if post.caption:
+                    (download_path / f"{shortcode}.txt").write_text(post.caption, encoding="utf-8")
 
-    async def _resolve_shortcode(self, session: AsyncSession, url: str) -> tuple[str, str]:
+                return post
+        finally:
+            if cookies_path and cookies_path.exists():
+                cookies_path.unlink(missing_ok=True)
+
+    async def _get_saved_instagram_cookies(self) -> Path | None:
+        try:
+            return await cookies_manager.get_cookies("instagram")
+        except Exception as exc:
+            logger.debug(f"Saved Instagram cookies are not available for HTTPCloak session: {exc}")
+            return None
+
+    async def _download_authenticated_fallback(
+        self,
+        canonical_url: str,
+        shortcode: str,
+        download_path: Path,
+    ) -> InstagramPost | None:
+        cookies_path = await cookies_manager.get_cookies("instagram")
+        credentials = self._configured_credentials()
+
+        if not cookies_path and not credentials:
+            return None
+
+        fallback_prefix = f".{shortcode}_yt_{secrets.token_hex(4)}"
+
+        ydl_opts = {
+            "outtmpl": str(download_path / f"{fallback_prefix}_%(id)s.%(ext)s"),
+            "extractor_retries": FALLBACK_RETRIES,
+            "file_access_retries": FALLBACK_RETRIES,
+            "logger": QuietYtdlpLogger(),
+            "merge_output_format": "mp4",
+            "noplaylist": True,
+            "quiet": True,
+            "noprogress": True,
+            "no_warnings": True,
+            "retries": FALLBACK_RETRIES,
+            "fragment_retries": FALLBACK_RETRIES,
+            "socket_timeout": 30,
+            "extractor_args": {"generic": ["impersonate=chrome"]},
+            "postprocessor_args": {"ffmpeg": ["-movflags", "faststart"]},
+        }
+
+        if cookies_path:
+            ydl_opts["cookiefile"] = str(cookies_path)
+            logger.info("Using saved Instagram cookies for media fallback")
+        elif credentials:
+            username, password = credentials
+            ydl_opts["username"] = username
+            ydl_opts["password"] = password
+            logger.info("Using configured Instagram credentials for media fallback")
+
+        info: dict[str, Any] | None = None
+        last_error: Exception | None = None
+        for attempt in range(1, FALLBACK_RETRIES + 1):
+            try:
+                info = await asyncio.to_thread(self._run_ytdlp_download, canonical_url, ydl_opts)
+                last_error = None
+                break
+            except Exception as exc:
+                last_error = exc
+                self._cleanup_temp_files(self._files_for_shortcode(download_path, fallback_prefix))
+                message = self._clean_ytdlp_error(str(exc))
+                logger.warning(f"Instagram media fallback attempt {attempt}/{FALLBACK_RETRIES} failed: {message}")
+                if attempt < FALLBACK_RETRIES and self._is_retryable_download_error(message):
+                    await asyncio.sleep(attempt * 2)
+                    continue
+                break
+
+        if last_error:
+            message = self._clean_ytdlp_error(str(last_error))
+            gallery_error = await asyncio.to_thread(
+                self._run_gallery_dl_download,
+                canonical_url,
+                download_path,
+                fallback_prefix,
+                cookies_path,
+                credentials,
+            )
+            if gallery_error:
+                if cookies_path and cookies_path.exists():
+                    cookies_path.unlink(missing_ok=True)
+                raise InstagramDownloadError(
+                    f"fallback через авторизацию не смог скачать медиа: yt-dlp: {message}; gallery-dl: {gallery_error}"
+                ) from last_error
+
+            last_error = None
+
+        files = self._files_for_shortcode(download_path, fallback_prefix)
+        media_files = [file_path for file_path in files if file_path.suffix.lower() in FALLBACK_MEDIA_EXTENSIONS]
+        non_media_files = [file_path for file_path in files if file_path not in media_files]
+        self._cleanup_temp_files(non_media_files)
+
+        if not media_files:
+            self._cleanup_temp_files(files)
+            if cookies_path and cookies_path.exists():
+                cookies_path.unlink(missing_ok=True)
+            raise InstagramNoMediaError("fallback через cookies завершился без медиафайлов.")
+
+        caption = self._caption_from_ytdlp_info(info)
+        self._cleanup_old_files(download_path, shortcode)
+        media_files = self._move_fallback_files(media_files, download_path, shortcode)
+
+        if caption:
+            (download_path / f"{shortcode}.txt").write_text(caption, encoding="utf-8")
+
+        if cookies_path and cookies_path.exists():
+            cookies_path.unlink(missing_ok=True)
+
+        return InstagramPost(
+            shortcode=shortcode,
+            canonical_url=canonical_url,
+            caption=caption,
+            media=[
+                InstagramMedia(
+                    url=file_path.as_uri(), is_video=file_path.suffix.lower() in VIDEO_EXTENSIONS, index=index
+                )
+                for index, file_path in enumerate(media_files, start=1)
+            ],
+        )
+
+    def _run_ytdlp_download(self, url: str, ydl_opts: dict[str, Any]) -> dict[str, Any] | None:
+        with YoutubeDL(ydl_opts) as ydl:  # type: ignore[arg-type]
+            return ydl.extract_info(url, download=True)  # type: ignore[no-any-return]
+
+    def _run_gallery_dl_download(
+        self,
+        url: str,
+        download_path: Path,
+        fallback_prefix: str,
+        cookies_path: Path | None,
+        credentials: tuple[str, str] | None,
+    ) -> str | None:
+        tmp_dir = download_path / f"{fallback_prefix}_gallery"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "gallery_dl",
+            "--no-colors",
+            "--no-part",
+            "--force-ipv4",
+            "--retries",
+            str(FALLBACK_RETRIES),
+            "--http-timeout",
+            "30",
+            "-D",
+            str(tmp_dir),
+        ]
+
+        if cookies_path:
+            cmd.extend(("--cookies", str(cookies_path)))
+            logger.info("Trying gallery-dl Instagram fallback with saved cookies")
+        elif credentials:
+            username, password = credentials
+            cmd.extend(("--username", username, "--password", password))
+            logger.info("Trying gallery-dl Instagram fallback with configured credentials")
+
+        cmd.append(url)
+
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                encoding="utf-8",
+                errors="replace",
+                text=True,
+                timeout=180,
+            )
+        except Exception as exc:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            return self._clean_ytdlp_error(str(exc))
+
+        output = (completed.stderr or completed.stdout or "").strip()
+        if completed.returncode != 0:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            return self._clean_ytdlp_error(output or f"exit code {completed.returncode}")
+
+        moved_count = 0
+        for source_path in sorted(tmp_dir.rglob("*")):
+            if not source_path.is_file():
+                continue
+
+            suffix = source_path.suffix.lower()
+            target_path = download_path / f"{fallback_prefix}_gallery_{moved_count + 1:02d}{suffix}"
+            shutil.move(str(source_path), target_path)
+            moved_count += 1
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        if moved_count == 0:
+            return "gallery-dl finished without files"
+
+        return None
+
+    def _configured_credentials(self) -> tuple[str, str] | None:
+        username = (INSTAGRAM_USERNAME or "").strip()
+        password = (INSTAGRAM_PASSWORD or "").strip()
+        if not username or username.lower() == "username" or not password:
+            return None
+        return username, password
+
+    def _files_for_shortcode(self, download_path: Path, shortcode: str) -> list[Path]:
+        return [
+            file_path
+            for file_path in download_path.iterdir()
+            if file_path.is_file() and file_path.name.startswith(shortcode) and not file_path.name.endswith(".part")
+        ]
+
+    def _move_fallback_files(self, files: list[Path], download_path: Path, shortcode: str) -> list[Path]:
+        moved_files: list[Path] = []
+
+        for index, source_path in enumerate(sorted(files), start=1):
+            suffix = source_path.suffix.lower() or ".mp4"
+            file_name = f"{shortcode}{suffix}" if len(files) == 1 else f"{shortcode}_{index:02d}{suffix}"
+            final_path = download_path / file_name
+            shutil.move(str(source_path), final_path)
+            moved_files.append(final_path)
+
+        return moved_files
+
+    def _cleanup_temp_files(self, files: list[Path]) -> None:
+        for file_path in files:
+            file_path.unlink(missing_ok=True)
+
+    def _caption_from_ytdlp_info(self, info: dict[str, Any] | None) -> str | None:
+        if not info:
+            return None
+
+        for key in ("description", "title"):
+            value = info.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        return None
+
+    def _clean_ytdlp_error(self, error: str) -> str:
+        cleaned = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", error)
+        cleaned = re.sub(r"\s+", " ", cleaned.replace("\r", " ").replace("\n", " ")).strip()
+        if cleaned.startswith("ERROR:"):
+            cleaned = cleaned.removeprefix("ERROR:").strip()
+        return cleaned[:300] + "..." if len(cleaned) > 300 else cleaned
+
+    def _is_retryable_download_error(self, error: str) -> bool:
+        error_lower = error.lower()
+        return any(
+            marker in error_lower
+            for marker in (
+                "failed to resolve",
+                "getaddrinfo failed",
+                "temporary failure",
+                "timed out",
+                "timeout",
+                "connection aborted",
+                "connection reset",
+            )
+        )
+
+    async def _resolve_shortcode(self, session: InstagramHttpSession, url: str) -> tuple[str, str]:
         match = re.search(r"/(p|reel|tv)/([\w-]+)", url)
         if match:
             media_type, shortcode = match.groups()
@@ -103,7 +579,7 @@ class InstagramWebDownloader:
 
         raise InstagramUnsupportedUrlError("Could not extract Instagram shortcode from the URL.")
 
-    async def _load_post(self, session: AsyncSession, shortcode: str, canonical_url: str) -> InstagramPost:
+    async def _load_post(self, session: InstagramHttpSession, shortcode: str, canonical_url: str) -> InstagramPost:
         html_text: str | None = None
         is_reel = "/reel/" in canonical_url
 
@@ -147,14 +623,16 @@ class InstagramWebDownloader:
             if post.media:
                 if is_reel and not any(media.is_video for media in post.media):
                     raise InstagramAuthRequiredError(
-                        "Instagram не отдал video URL для этого reel без cookies. "
-                        "Загрузи cookies через /set_cookies и попробуй /d_cookies <url>."
+                        "Instagram не отдал video URL для этого reel без авторизации. "
+                        "Загрузи cookies через /set_cookies и повтори /d <url>."
                     )
                 return post
 
         raise InstagramNoMediaError("No media metadata found on Instagram page.")
 
-    async def _load_json_candidates(self, session: AsyncSession, shortcode: str, canonical_url: str) -> list[Any]:
+    async def _load_json_candidates(
+        self, session: InstagramHttpSession, shortcode: str, canonical_url: str
+    ) -> list[Any]:
         candidates: list[Any] = []
         api_urls = [
             f"{canonical_url}?__a=1&__d=dis",
@@ -174,30 +652,24 @@ class InstagramWebDownloader:
 
         return candidates
 
-    async def _load_html(self, session: AsyncSession, canonical_url: str) -> str:
+    async def _load_html(self, session: InstagramHttpSession, canonical_url: str) -> str:
         response = await self._request(session, canonical_url)
         return response.text
 
     async def _request(
         self,
-        session: AsyncSession,
+        session: InstagramHttpSession,
         url: str,
         *,
         headers: dict[str, str] | None = None,
         allow_redirects: bool = True,
-    ) -> Response:
+    ) -> InstagramHttpResponse:
         request_headers = self._html_headers()
         if headers:
             request_headers.update(headers)
 
         try:
-            response = await session.get(
-                url,
-                allow_redirects=allow_redirects,
-                headers=request_headers,
-                impersonate="chrome",
-                timeout=REQUEST_TIMEOUT,
-            )
+            response = await session.get(url, allow_redirects=allow_redirects, headers=request_headers)
         except Exception as exc:
             raise InstagramDownloadError(f"Instagram request failed: {exc}") from exc
 
@@ -212,7 +684,7 @@ class InstagramWebDownloader:
 
     async def _download_media_files(
         self,
-        session: AsyncSession,
+        session: InstagramHttpSession,
         post: InstagramPost,
         download_path: Path,
     ) -> list[Path]:
@@ -248,6 +720,13 @@ class InstagramWebDownloader:
             "Cache-Control": "no-cache",
             "Pragma": "no-cache",
             "Referer": "https://www.instagram.com/",
+            "Sec-CH-UA": '"Google Chrome";v="149", "Chromium";v="149", "Not_A Brand";v="99"',
+            "Sec-CH-UA-Mobile": "?0",
+            "Sec-CH-UA-Platform": '"Windows"',
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
             "Upgrade-Insecure-Requests": "1",
         }
 
@@ -255,6 +734,12 @@ class InstagramWebDownloader:
         return {
             "Accept": "application/json,text/plain,*/*",
             "Referer": referer,
+            "Sec-CH-UA": '"Google Chrome";v="149", "Chromium";v="149", "Not_A Brand";v="99"',
+            "Sec-CH-UA-Mobile": "?0",
+            "Sec-CH-UA-Platform": '"Windows"',
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
             "X-IG-App-ID": INSTAGRAM_APP_ID,
             "X-ASBD-ID": "129477",
             "X-Requested-With": "XMLHttpRequest",
@@ -264,6 +749,12 @@ class InstagramWebDownloader:
         return {
             "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,video/*,*/*;q=0.8",
             "Referer": referer,
+            "Sec-CH-UA": '"Google Chrome";v="149", "Chromium";v="149", "Not_A Brand";v="99"',
+            "Sec-CH-UA-Mobile": "?0",
+            "Sec-CH-UA-Platform": '"Windows"',
+            "Sec-Fetch-Dest": "image",
+            "Sec-Fetch-Mode": "no-cors",
+            "Sec-Fetch-Site": "cross-site",
         }
 
     def _post_from_json(self, data: Any, shortcode: str, canonical_url: str) -> InstagramPost:
@@ -677,7 +1168,7 @@ async def get_instagram_shortcode(url: str) -> str | None:
     """
     try:
         client = await get_instaloader_session()
-        async with AsyncSession() as session:
+        async with InstagramHttpSession(client.http_preset) as session:
             shortcode, _ = await client._resolve_shortcode(session, url)
             return shortcode
     except Exception as exc:
@@ -690,14 +1181,12 @@ async def init_instaloader() -> InstagramWebDownloader:
 
     The public name is kept for backwards compatibility with existing routers.
     """
-    try:
-        user_agent = await instagram_ua_service.get_user_agent()
-        logger.info(f"Initializing custom Instagram downloader with UA: {user_agent[:50]}...")
-    except Exception as exc:
-        logger.warning(f"Failed to get dynamic User-Agent for Instagram downloader: {exc}, using fallback")
-        user_agent = InstagramUserAgentService.DEFAULT_USER_AGENT
+    http_preset = get_httpcloak_preset_name()
+    user_agent = os.getenv(HTTPCLOAK_USER_AGENT_ENV, CHROME_149_USER_AGENT).strip() or CHROME_149_USER_AGENT
+    logger.info(f"Initializing custom Instagram downloader with UA: {user_agent[:50]}...")
+    logger.info(f"Initializing Instagram HTTPCloak session with preset: {http_preset}")
 
-    return InstagramWebDownloader(user_agent=user_agent)
+    return InstagramWebDownloader(user_agent=user_agent, http_preset=http_preset)
 
 
 async def get_instaloader_session() -> InstagramWebDownloader:

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -1,185 +1,675 @@
 import asyncio
+import html
+import json
 import re
+import secrets
+import shutil
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
 
-import instaloader
-from curl_cffi.requests import AsyncSession
+from curl_cffi.requests import AsyncSession, Response
 
-from core.config import DOWNLOADS_DIR, INSTAGRAM_PASSWORD, INSTAGRAM_USERNAME, STORAGE_DIR
+from core.config import DOWNLOADS_DIR
 from core.logger import logger
-from tg_bot.services.instagram_ua_service import instagram_ua_service
+from tg_bot.services.instagram_ua_service import InstagramUserAgentService, instagram_ua_service
 
-INSTAGRAM_REGEX = re.compile(r"(https?:\/\/(?:www\.)?instagram\.com\/(?:share\/)?(p|reel|tv|stories)\/[\w\-]+)")
+INSTAGRAM_REGEX = re.compile(
+    r"(https?:\/\/(?:www\.)?instagram\.com\/(?:(?:p|reel|tv)\/[\w\-]+|share\/(?:p\/|reel\/|tv\/)?[\w\-]+|stories\/[\w.\-]+(?:\/\d+)?))"
+)
+
+INSTAGRAM_APP_ID = "936619743392459"
+REQUEST_TIMEOUT = 20
+SHORTCODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+
+class InstagramDownloadError(Exception):
+    """Base Instagram downloader error."""
+
+
+class InstagramAuthRequiredError(InstagramDownloadError):
+    """Instagram requires authentication for the requested media."""
+
+
+class InstagramRateLimitedError(InstagramDownloadError):
+    """Instagram blocked or rate-limited the request."""
+
+
+class InstagramUnsupportedUrlError(InstagramDownloadError):
+    """The Instagram URL shape is not supported by this downloader."""
+
+
+class InstagramNoMediaError(InstagramDownloadError):
+    """No downloadable media was found in Instagram responses."""
+
+
+@dataclass(slots=True)
+class InstagramMedia:
+    url: str
+    is_video: bool
+    index: int
+
+
+@dataclass(slots=True)
+class InstagramPost:
+    shortcode: str
+    canonical_url: str
+    caption: str | None
+    media: list[InstagramMedia]
+
+
+class InstagramWebDownloader:
+    """Small Instagram web downloader that does not depend on Instaloader."""
+
+    def __init__(self, user_agent: str):
+        self.user_agent = user_agent
+
+    async def download(self, url: str, download_path: Path = DOWNLOADS_DIR) -> InstagramPost:
+        download_path.mkdir(parents=True, exist_ok=True)
+
+        async with AsyncSession() as session:
+            shortcode, canonical_url = await self._resolve_shortcode(session, url)
+            post = await self._load_post(session, shortcode, canonical_url)
+
+            if not post.media:
+                raise InstagramNoMediaError("Instagram did not expose downloadable media for this post.")
+
+            self._cleanup_old_files(download_path, shortcode)
+            downloaded_files = await self._download_media_files(session, post, download_path)
+            if not downloaded_files:
+                raise InstagramNoMediaError("Instagram media links were found, but files were not downloaded.")
+
+            if post.caption:
+                (download_path / f"{shortcode}.txt").write_text(post.caption, encoding="utf-8")
+
+            return post
+
+    async def _resolve_shortcode(self, session: AsyncSession, url: str) -> tuple[str, str]:
+        match = re.search(r"/(p|reel|tv)/([\w-]+)", url)
+        if match:
+            media_type, shortcode = match.groups()
+            return shortcode, f"https://www.instagram.com/{media_type}/{shortcode}/"
+
+        if "/stories/" in url:
+            raise InstagramUnsupportedUrlError("Stories are not supported by the custom Instagram downloader yet.")
+
+        response = await self._request(session, url, allow_redirects=True)
+        final_url = str(response.url)
+        match = re.search(r"/(p|reel|tv)/([\w-]+)", final_url)
+        if match:
+            media_type, shortcode = match.groups()
+            return shortcode, f"https://www.instagram.com/{media_type}/{shortcode}/"
+
+        raise InstagramUnsupportedUrlError("Could not extract Instagram shortcode from the URL.")
+
+    async def _load_post(self, session: AsyncSession, shortcode: str, canonical_url: str) -> InstagramPost:
+        html_text: str | None = None
+
+        try:
+            html_text = await self._load_html(session, canonical_url)
+        except InstagramDownloadError as exc:
+            logger.debug(f"Instagram HTML page failed for {shortcode}: {exc}")
+
+        if html_text:
+            json_candidates = self._extract_json_candidates(html_text)
+            for candidate in json_candidates:
+                post = self._post_from_json(candidate, shortcode, canonical_url)
+                if post.media:
+                    return post
+
+        json_candidates = await self._load_json_candidates(session, shortcode, canonical_url)
+        for candidate in json_candidates:
+            post = self._post_from_json(candidate, shortcode, canonical_url)
+            if post.media:
+                return post
+
+        if html_text:
+            post = self._post_from_meta_tags(html_text, shortcode, canonical_url)
+            if post.media:
+                return post
+
+        raise InstagramNoMediaError("No media metadata found on Instagram page.")
+
+    async def _load_json_candidates(self, session: AsyncSession, shortcode: str, canonical_url: str) -> list[Any]:
+        candidates: list[Any] = []
+        api_urls = [
+            f"{canonical_url}?__a=1&__d=dis",
+            f"https://www.instagram.com/api/v1/media/{self._shortcode_to_media_id(shortcode)}/info/",
+        ]
+
+        for api_url in api_urls:
+            try:
+                response = await self._request(session, api_url, headers=self._json_headers(canonical_url))
+            except InstagramDownloadError as exc:
+                logger.debug(f"Instagram JSON endpoint failed: {api_url} - {exc}")
+                continue
+
+            parsed = self._try_load_json(response.text)
+            if parsed is not None:
+                candidates.append(parsed)
+
+        return candidates
+
+    async def _load_html(self, session: AsyncSession, canonical_url: str) -> str:
+        response = await self._request(session, canonical_url)
+        return response.text
+
+    async def _request(
+        self,
+        session: AsyncSession,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        allow_redirects: bool = True,
+    ) -> Response:
+        request_headers = self._html_headers()
+        if headers:
+            request_headers.update(headers)
+
+        try:
+            response = await session.get(
+                url,
+                allow_redirects=allow_redirects,
+                headers=request_headers,
+                impersonate="chrome",
+                timeout=REQUEST_TIMEOUT,
+            )
+        except Exception as exc:
+            raise InstagramDownloadError(f"Instagram request failed: {exc}") from exc
+
+        if response.status_code in (401, 403):
+            raise InstagramAuthRequiredError(f"Instagram returned HTTP {response.status_code}.")
+        if response.status_code == 429:
+            raise InstagramRateLimitedError("Instagram returned HTTP 429.")
+        if response.status_code >= 400:
+            raise InstagramDownloadError(f"Instagram returned HTTP {response.status_code}.")
+
+        return response
+
+    async def _download_media_files(
+        self,
+        session: AsyncSession,
+        post: InstagramPost,
+        download_path: Path,
+    ) -> list[Path]:
+        downloaded_files: list[Path] = []
+        media_headers = self._media_headers(post.canonical_url)
+
+        for media in post.media:
+            try:
+                response = await self._request(session, media.url, headers=media_headers)
+            except InstagramDownloadError as exc:
+                logger.warning(f"Failed to download Instagram media item {media.index}: {exc}")
+                continue
+
+            extension = self._guess_extension(media.url, response.headers.get("content-type"), media.is_video)
+            final_path = download_path / f"{post.shortcode}_{media.index:02d}{extension}"
+            tmp_path = download_path / f".{final_path.name}.{secrets.token_hex(4)}.part"
+
+            tmp_path.write_bytes(response.content)
+            if tmp_path.stat().st_size == 0:
+                tmp_path.unlink(missing_ok=True)
+                continue
+
+            shutil.move(str(tmp_path), final_path)
+            downloaded_files.append(final_path)
+
+        return downloaded_files
+
+    def _html_headers(self) -> dict[str, str]:
+        return {
+            "User-Agent": self.user_agent,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "Referer": "https://www.instagram.com/",
+            "Upgrade-Insecure-Requests": "1",
+        }
+
+    def _json_headers(self, referer: str) -> dict[str, str]:
+        return {
+            "Accept": "application/json,text/plain,*/*",
+            "Referer": referer,
+            "X-IG-App-ID": INSTAGRAM_APP_ID,
+            "X-ASBD-ID": "129477",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+
+    def _media_headers(self, referer: str) -> dict[str, str]:
+        return {
+            "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,video/*,*/*;q=0.8",
+            "Referer": referer,
+        }
+
+    def _post_from_json(self, data: Any, shortcode: str, canonical_url: str) -> InstagramPost:
+        root_nodes = self._find_shortcode_nodes(data, shortcode)
+        if not root_nodes:
+            root_nodes = self._find_media_roots(data)
+
+        media_items: list[InstagramMedia] = []
+        caption: str | None = None
+
+        for node in root_nodes:
+            if caption is None:
+                caption = self._extract_caption(node)
+            if caption is None:
+                caption = self._extract_caption_from_children(node)
+            media_items.extend(self._extract_media_from_node(node))
+
+        unique_media = self._dedupe_media(media_items)
+        return InstagramPost(shortcode=shortcode, canonical_url=canonical_url, caption=caption, media=unique_media)
+
+    def _find_shortcode_nodes(self, data: Any, shortcode: str) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+
+        def walk(value: Any) -> None:
+            if isinstance(value, dict):
+                shortcode_media = value.get("shortcode_media") or value.get("xdt_shortcode_media")
+                if isinstance(shortcode_media, dict):
+                    nodes.append(shortcode_media)
+
+                if value.get("shortcode") == shortcode or value.get("code") == shortcode:
+                    nodes.append(value)
+
+                for child in value.values():
+                    walk(child)
+            elif isinstance(value, list):
+                for item in value:
+                    walk(item)
+
+        walk(data)
+        return nodes
+
+    def _find_media_roots(self, data: Any) -> list[dict[str, Any]]:
+        roots: list[dict[str, Any]] = []
+
+        def walk(value: Any) -> None:
+            if isinstance(value, dict):
+                if self._node_has_media(value):
+                    roots.append(value)
+                    return
+                for child in value.values():
+                    walk(child)
+            elif isinstance(value, list):
+                for item in value:
+                    walk(item)
+
+        walk(data)
+        return roots
+
+    def _extract_media_from_node(self, node: dict[str, Any]) -> list[InstagramMedia]:
+        media_nodes = self._flatten_media_nodes(node)
+        media_items: list[InstagramMedia] = []
+
+        for index, media_node in enumerate(media_nodes, start=1):
+            media_url = self._pick_video_url(media_node)
+            if media_url:
+                media_items.append(InstagramMedia(url=media_url, is_video=True, index=index))
+                continue
+
+            image_url = self._pick_image_url(media_node)
+            if image_url:
+                media_items.append(InstagramMedia(url=image_url, is_video=False, index=index))
+
+        return media_items
+
+    def _flatten_media_nodes(self, node: dict[str, Any]) -> list[dict[str, Any]]:
+        for key in ("edge_sidecar_to_children", "edge_web_media_to_related_media"):
+            edges = ((node.get(key) or {}).get("edges")) if isinstance(node.get(key), dict) else None
+            if isinstance(edges, list) and edges:
+                children = [edge.get("node") for edge in edges if isinstance(edge, dict)]
+                return [child for child in children if isinstance(child, dict)]
+
+        carousel_media = node.get("carousel_media")
+        if isinstance(carousel_media, list) and carousel_media:
+            return [item for item in carousel_media if isinstance(item, dict)]
+
+        items = node.get("items")
+        if isinstance(items, list) and items:
+            return [item for item in items if isinstance(item, dict)]
+
+        return [node]
+
+    def _pick_video_url(self, node: dict[str, Any]) -> str | None:
+        video_url = node.get("video_url")
+        if isinstance(video_url, str):
+            return html.unescape(video_url)
+
+        video_versions = node.get("video_versions")
+        if isinstance(video_versions, list):
+            return self._pick_best_candidate_url(video_versions)
+
+        return None
+
+    def _pick_image_url(self, node: dict[str, Any]) -> str | None:
+        image_versions = (node.get("image_versions2") or {}).get("candidates")
+        if isinstance(image_versions, list):
+            candidate = self._pick_best_candidate_url(image_versions)
+            if candidate:
+                return candidate
+
+        display_resources = node.get("display_resources") or node.get("thumbnail_resources")
+        if isinstance(display_resources, list):
+            candidate = self._pick_best_candidate_url(display_resources)
+            if candidate:
+                return candidate
+
+        for key in ("display_url", "thumbnail_src", "url"):
+            value = node.get(key)
+            if isinstance(value, str) and self._looks_like_media_url(value):
+                return html.unescape(value)
+
+        return None
+
+    def _pick_best_candidate_url(self, candidates: list[Any]) -> str | None:
+        best_candidate: dict[str, Any] | None = None
+        best_score = -1
+
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+
+            url = candidate.get("url") or candidate.get("src")
+            if not isinstance(url, str):
+                continue
+
+            width = self._safe_int(candidate.get("width") or candidate.get("config_width"))
+            height = self._safe_int(candidate.get("height") or candidate.get("config_height"))
+            score = width * height
+
+            if score > best_score:
+                best_candidate = candidate
+                best_score = score
+
+        if not best_candidate:
+            return None
+
+        url = best_candidate.get("url") or best_candidate.get("src")
+        return html.unescape(url) if isinstance(url, str) else None
+
+    def _extract_caption(self, node: dict[str, Any]) -> str | None:
+        caption = node.get("caption")
+        if isinstance(caption, str):
+            return caption.strip() or None
+        if isinstance(caption, dict):
+            caption_text = caption.get("text")
+            if isinstance(caption_text, str):
+                return caption_text.strip() or None
+
+        for key in ("caption_text", "edge_media_to_caption"):
+            value = node.get(key)
+            if isinstance(value, str):
+                return value.strip() or None
+            if isinstance(value, dict):
+                edges = value.get("edges")
+                if isinstance(edges, list):
+                    for edge in edges:
+                        text = ((edge or {}).get("node") or {}).get("text") if isinstance(edge, dict) else None
+                        if isinstance(text, str) and text.strip():
+                            return text.strip()
+
+        return None
+
+    def _extract_caption_from_children(self, node: dict[str, Any]) -> str | None:
+        for child in self._flatten_media_nodes(node):
+            caption = self._extract_caption(child)
+            if caption:
+                return caption
+
+        return None
+
+    def _extract_json_candidates(self, html_text: str) -> list[Any]:
+        candidates: list[Any] = []
+
+        for match in re.finditer(
+            r"<script[^>]*type=[\"']application/(?:json|ld\+json)[\"'][^>]*>(.*?)</script>",
+            html_text,
+            flags=re.IGNORECASE | re.DOTALL,
+        ):
+            parsed = self._try_load_json(html.unescape(match.group(1)).strip())
+            if parsed is not None:
+                candidates.append(parsed)
+
+        for marker in ("window._sharedData", "shortcode_media", "xdt_shortcode_media"):
+            for json_text in self._extract_balanced_json_after_marker(html_text, marker):
+                parsed = self._try_load_json(html.unescape(json_text))
+                if parsed is not None:
+                    candidates.append(parsed)
+
+        return candidates
+
+    def _extract_balanced_json_after_marker(self, text: str, marker: str) -> list[str]:
+        chunks: list[str] = []
+        start = 0
+
+        while True:
+            marker_index = text.find(marker, start)
+            if marker_index == -1:
+                break
+
+            brace_index = text.find("{", marker_index)
+            if brace_index == -1:
+                break
+
+            chunk = self._balanced_json_object(text, brace_index)
+            if chunk:
+                chunks.append(chunk)
+
+            start = marker_index + len(marker)
+
+        return chunks
+
+    def _balanced_json_object(self, text: str, start: int) -> str | None:
+        depth = 0
+        in_string = False
+        escaped = False
+
+        for index in range(start, len(text)):
+            char = text[index]
+
+            if escaped:
+                escaped = False
+                continue
+
+            if char == "\\":
+                escaped = True
+                continue
+
+            if char == '"':
+                in_string = not in_string
+                continue
+
+            if in_string:
+                continue
+
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+
+        return None
+
+    def _post_from_meta_tags(self, html_text: str, shortcode: str, canonical_url: str) -> InstagramPost:
+        media: list[InstagramMedia] = []
+        caption: str | None = None
+
+        for match in re.finditer(
+            r"<meta\s+[^>]*(?:property|name)=[\"']og:(video|image|description)[\"'][^>]*>",
+            html_text,
+            flags=re.IGNORECASE,
+        ):
+            content_match = re.search(r"content=[\"']([^\"']+)[\"']", match.group(0), flags=re.IGNORECASE)
+            if not content_match:
+                continue
+
+            value = html.unescape(content_match.group(1))
+            media_type = match.group(1).lower()
+
+            if media_type == "video" and self._looks_like_media_url(value):
+                media.append(InstagramMedia(url=value, is_video=True, index=len(media) + 1))
+            elif media_type == "image" and self._looks_like_media_url(value):
+                media.append(InstagramMedia(url=value, is_video=False, index=len(media) + 1))
+            elif media_type == "description":
+                caption = value.strip() or None
+
+        return InstagramPost(
+            shortcode=shortcode,
+            canonical_url=canonical_url,
+            caption=caption,
+            media=self._dedupe_media(media),
+        )
+
+    def _dedupe_media(self, media_items: list[InstagramMedia]) -> list[InstagramMedia]:
+        unique_items: list[InstagramMedia] = []
+        seen_urls: set[str] = set()
+
+        for media in media_items:
+            dedupe_key = media.url.split("?", maxsplit=1)[0]
+            if dedupe_key in seen_urls:
+                continue
+            seen_urls.add(dedupe_key)
+            unique_items.append(InstagramMedia(url=media.url, is_video=media.is_video, index=len(unique_items) + 1))
+
+        return unique_items
+
+    def _node_has_media(self, value: dict[str, Any]) -> bool:
+        return any(
+            key in value
+            for key in (
+                "video_url",
+                "video_versions",
+                "display_url",
+                "display_resources",
+                "image_versions2",
+                "carousel_media",
+                "edge_sidecar_to_children",
+            )
+        )
+
+    def _looks_like_media_url(self, value: str) -> bool:
+        value_lower = value.lower()
+        return value_lower.startswith("http") and any(
+            marker in value_lower for marker in ("cdninstagram", "fbcdn", ".cdn", "scontent")
+        )
+
+    def _try_load_json(self, text: str) -> Any | None:
+        if not text:
+            return None
+
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+    def _shortcode_to_media_id(self, shortcode: str) -> int:
+        media_id = 0
+        for char in shortcode:
+            media_id = media_id * 64 + SHORTCODE_ALPHABET.index(char)
+        return media_id
+
+    def _safe_int(self, value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    def _guess_extension(self, url: str, content_type: str | None, is_video: bool) -> str:
+        content_type = (content_type or "").split(";", maxsplit=1)[0].lower()
+        if content_type == "video/mp4":
+            return ".mp4"
+        if content_type == "image/webp":
+            return ".webp"
+        if content_type in ("image/jpeg", "image/jpg"):
+            return ".jpg"
+        if content_type == "image/png":
+            return ".png"
+
+        path_suffix = Path(urlparse(url).path).suffix.lower()
+        if path_suffix in (".mp4", ".mov", ".jpg", ".jpeg", ".png", ".webp"):
+            return ".jpg" if path_suffix == ".jpeg" else path_suffix
+
+        return ".mp4" if is_video else ".jpg"
+
+    def _cleanup_old_files(self, download_path: Path, shortcode: str) -> None:
+        for file_path in download_path.iterdir():
+            if file_path.is_file() and file_path.name.startswith(shortcode):
+                file_path.unlink(missing_ok=True)
+
+
+_instagram_client: InstagramWebDownloader | None = None
 
 
 async def get_instagram_shortcode(url: str) -> str | None:
     """
-    Определяет shortcode поста Instagram (редиректим сразу).
+    Resolve an Instagram post shortcode.
     """
-    # Импортируем сервис внутри функции для избежания циклических импортов
+    try:
+        client = await get_instaloader_session()
+        async with AsyncSession() as session:
+            shortcode, _ = await client._resolve_shortcode(session, url)
+            return shortcode
+    except Exception as exc:
+        logger.error(f"Ошибка при получении Instagram shortcode: {exc}")
+        return None
+
+
+async def init_instaloader() -> InstagramWebDownloader:
+    """Initialize the custom Instagram web downloader.
+
+    The public name is kept for backwards compatibility with existing routers.
+    """
     try:
         user_agent = await instagram_ua_service.get_user_agent()
-        logger.debug(f"Using User-Agent: {user_agent[:50]}...")
-    except Exception as e:
-        logger.warning(f"Failed to get dynamic User-Agent: {e}, using fallback")
-        user_agent = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Mobile Safari/537.36"
+        logger.info(f"Initializing custom Instagram downloader with UA: {user_agent[:50]}...")
+    except Exception as exc:
+        logger.warning(f"Failed to get dynamic User-Agent for Instagram downloader: {exc}, using fallback")
+        user_agent = InstagramUserAgentService.DEFAULT_USER_AGENT
 
-    async with AsyncSession() as session:
-        try:
-            headers = {
-                "User-Agent": user_agent,
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.5",
-                "Accept-Encoding": "gzip, deflate, br",
-                "DNT": "1",
-                "Connection": "keep-alive",
-                "Upgrade-Insecure-Requests": "1",
-            }
-            match = re.search(r"/(p|reel|tv)/([\w-]+)", url)
-            if not match:
-                logger.info(f"Current {url} doesn't have shortcode, redirect")
-                response = await session.get(
-                    url, allow_redirects=True, impersonate="chrome", headers=headers, timeout=10
-                )  # type: ignore
-
-                final_url = str(response.url)  # Итоговый URL
-                match = re.search(r"/(p|reel|tv)/([\w-]+)", final_url)
-            if match:
-                shortcode = match.group(2)
-                logger.info(f"Extracted shortcode: {shortcode}")
-                return shortcode
-
-        except Exception as e:
-            logger.error(f"Ошибка при редиректе Instagram URL: {e}")
-            return None
-
-    return None  # Shortcode не найден
+    return InstagramWebDownloader(user_agent=user_agent)
 
 
-async def init_instaloader():
-    """Инициализация Instaloader с динамическим User-Agent"""
-    try:
-        user_agent = await instagram_ua_service.get_user_agent()
-        logger.info(f"Initializing Instaloader with UA: {user_agent[:50]}...")
-    except Exception as e:
-        logger.warning(f"Failed to get dynamic User-Agent for Instaloader: {e}, using fallback")
-        user_agent = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Mobile Safari/537.36"
+async def get_instaloader_session() -> InstagramWebDownloader:
+    """Get or create the custom Instagram downloader instance.
 
-    bot_loader = instaloader.Instaloader(
-        filename_pattern="{shortcode}",
-        iphone_support=False,
-        user_agent=user_agent,
-        quiet=True,  # Убираем лишние выводы
-        download_pictures=True,
-        download_videos=True,
-        download_video_thumbnails=False,
-        download_geotags=False,
-        download_comments=False,
-        save_metadata=False,
-        fatal_status_codes=[302, 400, 401, 429, 403],
-    )
-
-    try:
-        if INSTAGRAM_USERNAME:
-            session_loaded = False
-            try:
-                bot_loader.load_session_from_file(
-                    INSTAGRAM_USERNAME,
-                    str((STORAGE_DIR / "session" / f"session-{INSTAGRAM_USERNAME}").absolute()),
-                )
-                if bot_loader.test_login():
-                    logger.success(f"Instaloader session loaded for user: {INSTAGRAM_USERNAME}")
-                    session_loaded = True
-                else:
-                    logger.warning("⚠️ Session from file is invalid.")
-            except FileNotFoundError:
-                logger.warning("⚠️ Session file not found. Attempting login with password.")
-            except KeyError:
-                logger.warning("⚠️ Session file is corrupted or missing required data. Attempting login with password.")
-
-            if not session_loaded and INSTAGRAM_PASSWORD:
-                logger.info(f"Attempting to log in as {INSTAGRAM_USERNAME}...")
-                bot_loader.login(INSTAGRAM_USERNAME, INSTAGRAM_PASSWORD)
-                if bot_loader.test_login():
-                    logger.success(f"Successfully logged in as {INSTAGRAM_USERNAME}")
-                    # Сохраняем сессию для будущих запусков
-                    bot_loader.save_session_to_file(
-                        str((STORAGE_DIR / "session" / f"session-{INSTAGRAM_USERNAME}").absolute())
-                    )
-                else:
-                    logger.error("❌ Login failed with username/password. Check credentials.")
-            elif not session_loaded:
-                logger.warning("No password provided. Only public posts can be downloaded.")
-        else:
-            logger.info("No Instagram username provided. Only public posts can be downloaded.")
-
-    except instaloader.exceptions.QueryReturnedBadRequestException as e:
-        if "checkpoint" in str(e):
-            logger.error("Инста забанила акк, надо разблочиться")
-    except Exception as e:
-        logger.exception(f"An unexpected error occurred during Instaloader session setup: {e}")
-    return bot_loader
+    The public name is kept for backwards compatibility with existing routers.
+    """
+    global _instagram_client
+    if _instagram_client is None:
+        _instagram_client = await init_instaloader()
+    return _instagram_client
 
 
-# Кэш для Instaloader инстанса
-_instaloader_session = None
-
-
-async def get_instaloader_session():
-    """Получает или создает инстанс Instaloader."""
-    global _instaloader_session
-    if _instaloader_session is None:
-        _instaloader_session = await init_instaloader()
-    return _instaloader_session
-
-
-async def reset_instaloader_session():
-    """Сбрасывает кэш Instaloader для пересоздания с новым User-Agent."""
-    global _instaloader_session
-    _instaloader_session = None
-    logger.info("Instagram loader cache reset")
+async def reset_instaloader_session() -> None:
+    """Reset the cached Instagram downloader so a fresh User-Agent is used."""
+    global _instagram_client
+    _instagram_client = None
+    logger.info("Instagram downloader cache reset")
 
 
 async def download_instagram_media(url: str) -> tuple[str | None, str | None]:
-    """Асинхронно загружает посты Instagram (фото, видео, текст)
-    и возвращает shortcode и ошибку, если есть."""
+    """Download Instagram post media and return shortcode plus a user-facing error."""
     try:
-        shortcode: str | None = await get_instagram_shortcode(url)
-        if not shortcode:
-            return None, "❌ Ошибка: Не удалось извлечь shortcode из ссылки."
-
-        bot_loader = await get_instaloader_session()
-
-        loop = asyncio.get_event_loop()
-        post = await loop.run_in_executor(None, instaloader.Post.from_shortcode, bot_loader.context, shortcode)
-        await loop.run_in_executor(None, bot_loader.download_post, post, DOWNLOADS_DIR)
-
-        return shortcode, None
-
-    except instaloader.exceptions.LoginRequiredException:
+        client = await get_instaloader_session()
+        post = await client.download(url, DOWNLOADS_DIR)
+        return post.shortcode, None
+    except InstagramUnsupportedUrlError as exc:
+        return None, f"❌ Ошибка: {exc}"
+    except InstagramAuthRequiredError:
         return None, "❌ Ошибка: Требуется авторизация в Instagram для этого контента."
-
-    except (instaloader.exceptions.BadResponseException, instaloader.exceptions.ConnectionException):
-        # При плохом ответе пытаемся обновить User-Agent и пересоздать сессию
-        try:
-            # Получаем новый User-Agent (будет автоматически взят из Redis)
-            await instagram_ua_service.get_user_agent()
-            global _instaloader_session
-            _instaloader_session = None  # Сбрасываем кэш для пересоздания с новым UA
-            logger.warning("Instagram blocked access, refreshed User-Agent and reset cache...")
-        except Exception as e:
-            logger.error(f"Failed to refresh User-Agent: {e}")
-
-        return None, "❌ Ошибка: Instagram заблокировал доступ. Попробуйте обновить User-Agent командой /ua_set"
-
-    except instaloader.exceptions.QueryReturnedBadRequestException as e:
-        if "checkpoint" in str(e):
-            return None, "❌ Ошибка: Instagram забанил акк. Надо разблочить"
-
-    except Exception as e:
-        return None, f"❌ Ошибка: {e}"
-
-    return None, f"Хз, ничего не скачалось. {url}"
+    except InstagramRateLimitedError:
+        await reset_instaloader_session()
+        return None, "❌ Ошибка: Instagram ограничил доступ. Попробуйте обновить User-Agent командой /ua_set"
+    except InstagramNoMediaError as exc:
+        return None, f"❌ Ошибка: Не удалось найти медиа в посте. {exc}"
+    except InstagramDownloadError as exc:
+        return None, f"❌ Ошибка Instagram: {exc}"
+    except Exception as exc:
+        logger.exception(f"Unexpected Instagram downloader error: {exc}")
+        return None, f"❌ Ошибка: {exc}"
 
 
 DOWNLOADS_DIR.mkdir(exist_ok=True)
@@ -187,23 +677,22 @@ DOWNLOADS_DIR.mkdir(exist_ok=True)
 
 async def select_instagram_media(shortcode: str, download_path: Path = DOWNLOADS_DIR) -> dict[str, list[Path] | str]:
     """
-    Определяет, какие файлы скачал Instaloader, и выбирает нужный формат для отправки.
+    Select the files downloaded by the custom Instagram downloader.
     """
-    files = [f for f in download_path.iterdir() if f.name.startswith(shortcode)]
+    files = [file_path for file_path in download_path.iterdir() if file_path.name.startswith(shortcode)]
 
     images: list[Path] = []
     videos: list[Path] = []
-    caption: str = ""
+    caption = ""
 
     for file_path in files:
         suffix = file_path.suffix.lower()
 
-        # Определяем тип файла
-        if suffix in (".jpg", ".jpeg", ".png"):
+        if suffix in (".jpg", ".jpeg", ".png", ".webp"):
             images.append(file_path)
         elif suffix in (".mp4", ".mov"):
             videos.append(file_path)
         elif suffix == ".txt":
-            caption = file_path.read_text(encoding="utf-8")  # Читаем описание поста
+            caption = await asyncio.to_thread(file_path.read_text, encoding="utf-8")
 
     return {"images": images, "videos": videos, "caption": caption}

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -105,6 +105,7 @@ class InstagramWebDownloader:
 
     async def _load_post(self, session: AsyncSession, shortcode: str, canonical_url: str) -> InstagramPost:
         html_text: str | None = None
+        is_reel = "/reel/" in canonical_url
 
         try:
             html_text = await self._load_html(session, canonical_url)
@@ -118,19 +119,23 @@ class InstagramWebDownloader:
             for candidate in json_candidates:
                 post = self._post_from_json(candidate, shortcode, canonical_url)
                 if post.media:
-                    if (
-                        "/reel/" in canonical_url
-                        and raw_video_post.media
-                        and not any(media.is_video for media in post.media)
-                    ):
+                    if is_reel and any(media.is_video for media in post.media):
+                        return post
+                    if is_reel and raw_video_post.media and not any(media.is_video for media in post.media):
                         logger.debug(f"Using raw Instagram video URL fallback for reel {shortcode}")
                         return raw_video_post
+                    if is_reel:
+                        logger.debug(f"Ignoring image-only Instagram reel metadata for {shortcode}")
+                        continue
                     return post
 
         json_candidates = await self._load_json_candidates(session, shortcode, canonical_url)
         for candidate in json_candidates:
             post = self._post_from_json(candidate, shortcode, canonical_url)
             if post.media:
+                if is_reel and not any(media.is_video for media in post.media):
+                    logger.debug(f"Ignoring image-only Instagram reel API metadata for {shortcode}")
+                    continue
                 return post
 
         if raw_video_post and raw_video_post.media:
@@ -140,6 +145,11 @@ class InstagramWebDownloader:
         if html_text:
             post = self._post_from_meta_tags(html_text, shortcode, canonical_url)
             if post.media:
+                if is_reel and not any(media.is_video for media in post.media):
+                    raise InstagramAuthRequiredError(
+                        "Instagram не отдал video URL для этого reel без cookies. "
+                        "Загрузи cookies через /set_cookies и попробуй /d_cookies <url>."
+                    )
                 return post
 
         raise InstagramNoMediaError("No media metadata found on Instagram page.")
@@ -716,8 +726,9 @@ async def download_instagram_media(url: str) -> tuple[str | None, str | None]:
         return post.shortcode, None
     except InstagramUnsupportedUrlError as exc:
         return None, f"❌ Ошибка: {exc}"
-    except InstagramAuthRequiredError:
-        return None, "❌ Ошибка: Требуется авторизация в Instagram для этого контента."
+    except InstagramAuthRequiredError as exc:
+        message = str(exc) or "Требуется авторизация в Instagram для этого контента."
+        return None, f"❌ Ошибка: {message}"
     except InstagramRateLimitedError:
         await reset_instaloader_session()
         return None, "❌ Ошибка: Instagram ограничил доступ. Попробуйте обновить User-Agent командой /ua_set"

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -1,21 +1,17 @@
 import asyncio
 import html
 import json
-import os
 import re
 import secrets
 import shutil
-import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 import httpcloak
-from yt_dlp import YoutubeDL
 
-from core.config import DOWNLOADS_DIR, INSTAGRAM_PASSWORD, INSTAGRAM_USERNAME
+from core.config import DOWNLOADS_DIR
 from core.logger import logger
 from tg_bot.utils.cookies_manager import cookies_manager
 
@@ -27,21 +23,20 @@ INSTAGRAM_APP_ID = "936619743392459"
 REQUEST_TIMEOUT = 20
 SHORTCODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 VIDEO_EXTENSIONS = (".mp4", ".mov", ".mkv", ".webm")
-IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
-FALLBACK_MEDIA_EXTENSIONS = VIDEO_EXTENSIONS + IMAGE_EXTENSIONS
-FALLBACK_RETRIES = 3
+REQUEST_RETRIES = 3
 CHROME_149_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
 )
-HTTPCLOAK_DEFAULT_PRESET = "chrome-149-windows"
-HTTPCLOAK_CUSTOM_PRESET_NAME = "instagram-chrome149"
-HTTPCLOAK_FALLBACK_PRESET = "chrome-latest"
-HTTPCLOAK_USER_AGENT_ENV = "INSTAGRAM_HTTPCLOAK_USER_AGENT"
-HTTPCLOAK_PRESET_ENV = "INSTAGRAM_HTTPCLOAK_PRESET"
-HTTPCLOAK_PRESET_JSON_ENV = "INSTAGRAM_HTTPCLOAK_PRESET_JSON"
-HTTPCLOAK_PRESET_FILE_ENV = "INSTAGRAM_HTTPCLOAK_PRESET_FILE"
-HTTPCLOAK_JA3_ENV = "INSTAGRAM_HTTPCLOAK_JA3"
-HTTPCLOAK_AKAMAI_ENV = "INSTAGRAM_HTTPCLOAK_AKAMAI"
+INSTAGRAM_HTTP_PRESET_NAME = "instagram-chrome149"
+INSTAGRAM_HTTP_PRESET_JSON = json.dumps(
+    {
+        "version": 1,
+        "preset": {
+            "name": INSTAGRAM_HTTP_PRESET_NAME,
+            "extends": "chrome-149-windows",
+        },
+    }
+)
 
 
 class InstagramDownloadError(Exception):
@@ -93,7 +88,7 @@ class InstagramHttpSession:
         self._session = httpcloak.Session(
             preset=preset,
             timeout=REQUEST_TIMEOUT,
-            retry=FALLBACK_RETRIES,
+            retry=REQUEST_RETRIES,
             prefer_ipv4=True,
             http_version="auto",
         )
@@ -172,97 +167,13 @@ class InstagramHttpSession:
         return normalized
 
 
-class QuietYtdlpLogger:
-    def debug(self, message: str) -> None:
-        pass
-
-    def warning(self, message: str) -> None:
-        logger.debug(f"yt-dlp warning: {message}")
-
-    def error(self, message: str) -> None:
-        logger.debug(f"yt-dlp error: {message}")
-
-
-_httpcloak_preset_name: str | None = None
-
-
 def get_httpcloak_preset_name() -> str:
-    global _httpcloak_preset_name
-    if _httpcloak_preset_name:
-        return _httpcloak_preset_name
-
-    custom_preset = _load_custom_httpcloak_preset()
-    if custom_preset:
-        _httpcloak_preset_name = custom_preset
-        return custom_preset
-
-    requested_preset = os.getenv(HTTPCLOAK_PRESET_ENV, HTTPCLOAK_DEFAULT_PRESET).strip() or HTTPCLOAK_DEFAULT_PRESET
-    base_preset = _first_available_httpcloak_preset(requested_preset)
-    preset_name = _register_instagram_httpcloak_preset(base_preset)
-    _httpcloak_preset_name = preset_name
-    return preset_name
-
-
-def _load_custom_httpcloak_preset() -> str | None:
-    preset_json = os.getenv(HTTPCLOAK_PRESET_JSON_ENV)
-    preset_file = os.getenv(HTTPCLOAK_PRESET_FILE_ENV)
-
-    if preset_file:
-        try:
-            preset_json = Path(preset_file).read_text(encoding="utf-8")
-        except Exception as exc:
-            logger.warning(f"Failed to read Instagram HTTPCloak preset file: {exc}")
-
-    if not preset_json:
-        return None
-
-    return _load_httpcloak_preset_json(preset_json, HTTPCLOAK_CUSTOM_PRESET_NAME)
-
-
-def _first_available_httpcloak_preset(requested_preset: str) -> str:
     try:
-        httpcloak.describe_preset(requested_preset)
-        return requested_preset
-    except Exception as exc:
-        logger.warning(
-            f"HTTPCloak preset {requested_preset!r} is not available ({exc}); using {HTTPCLOAK_FALLBACK_PRESET!r}"
-        )
-        return HTTPCLOAK_FALLBACK_PRESET
-
-
-def _register_instagram_httpcloak_preset(base_preset: str) -> str:
-    try:
-        preset_json = httpcloak.describe_preset(base_preset)
-    except Exception as exc:
-        logger.warning(f"Failed to describe HTTPCloak preset {base_preset!r}: {exc}; using preset directly")
-        return base_preset
-
-    return _load_httpcloak_preset_json(preset_json, HTTPCLOAK_CUSTOM_PRESET_NAME, force_name=True)
-
-
-def _load_httpcloak_preset_json(preset_json: str, fallback_name: str, *, force_name: bool = False) -> str:
-    spec = json.loads(preset_json)
-    preset = spec.setdefault("preset", {})
-    preset_name = fallback_name if force_name else str(preset.get("name") or fallback_name)
-    preset["name"] = preset_name
-
-    ja3 = os.getenv(HTTPCLOAK_JA3_ENV)
-    if ja3:
-        preset["tls"] = {"ja3": ja3}
-
-    akamai = os.getenv(HTTPCLOAK_AKAMAI_ENV)
-    if akamai:
-        http2 = preset.setdefault("http2", {})
-        http2["akamai"] = akamai
-
-    serialized = json.dumps(spec)
-    try:
-        httpcloak.load_preset_from_json(serialized)
+        return httpcloak.load_preset_from_json(INSTAGRAM_HTTP_PRESET_JSON)
     except Exception as exc:
         if "already" not in str(exc).lower() and "exist" not in str(exc).lower():
-            raise
-
-    return preset_name
+            logger.warning(f"Failed to register Instagram HTTPCloak preset: {exc}")
+        return INSTAGRAM_HTTP_PRESET_NAME
 
 
 class InstagramWebDownloader:
@@ -282,13 +193,7 @@ class InstagramWebDownloader:
                     session.load_netscape_cookies(cookies_path)
 
                 shortcode, canonical_url = await self._resolve_shortcode(session, url)
-                try:
-                    post = await self._load_post(session, shortcode, canonical_url)
-                except (InstagramAuthRequiredError, InstagramNoMediaError) as exc:
-                    fallback_post = await self._download_authenticated_fallback(canonical_url, shortcode, download_path)
-                    if fallback_post:
-                        return fallback_post
-                    raise exc
+                post = await self._load_post(session, shortcode, canonical_url)
 
                 if not post.media:
                     raise InstagramNoMediaError("Instagram did not expose downloadable media for this post.")
@@ -312,254 +217,6 @@ class InstagramWebDownloader:
         except Exception as exc:
             logger.debug(f"Saved Instagram cookies are not available for HTTPCloak session: {exc}")
             return None
-
-    async def _download_authenticated_fallback(
-        self,
-        canonical_url: str,
-        shortcode: str,
-        download_path: Path,
-    ) -> InstagramPost | None:
-        cookies_path = await cookies_manager.get_cookies("instagram")
-        credentials = self._configured_credentials()
-
-        if not cookies_path and not credentials:
-            return None
-
-        fallback_prefix = f".{shortcode}_yt_{secrets.token_hex(4)}"
-
-        ydl_opts = {
-            "outtmpl": str(download_path / f"{fallback_prefix}_%(id)s.%(ext)s"),
-            "extractor_retries": FALLBACK_RETRIES,
-            "file_access_retries": FALLBACK_RETRIES,
-            "logger": QuietYtdlpLogger(),
-            "merge_output_format": "mp4",
-            "noplaylist": True,
-            "quiet": True,
-            "noprogress": True,
-            "no_warnings": True,
-            "retries": FALLBACK_RETRIES,
-            "fragment_retries": FALLBACK_RETRIES,
-            "socket_timeout": 30,
-            "extractor_args": {"generic": ["impersonate=chrome"]},
-            "postprocessor_args": {"ffmpeg": ["-movflags", "faststart"]},
-        }
-
-        if cookies_path:
-            ydl_opts["cookiefile"] = str(cookies_path)
-            logger.info("Using saved Instagram cookies for media fallback")
-        elif credentials:
-            username, password = credentials
-            ydl_opts["username"] = username
-            ydl_opts["password"] = password
-            logger.info("Using configured Instagram credentials for media fallback")
-
-        info: dict[str, Any] | None = None
-        last_error: Exception | None = None
-        for attempt in range(1, FALLBACK_RETRIES + 1):
-            try:
-                info = await asyncio.to_thread(self._run_ytdlp_download, canonical_url, ydl_opts)
-                last_error = None
-                break
-            except Exception as exc:
-                last_error = exc
-                self._cleanup_temp_files(self._files_for_shortcode(download_path, fallback_prefix))
-                message = self._clean_ytdlp_error(str(exc))
-                logger.warning(f"Instagram media fallback attempt {attempt}/{FALLBACK_RETRIES} failed: {message}")
-                if attempt < FALLBACK_RETRIES and self._is_retryable_download_error(message):
-                    await asyncio.sleep(attempt * 2)
-                    continue
-                break
-
-        if last_error:
-            message = self._clean_ytdlp_error(str(last_error))
-            gallery_error = await asyncio.to_thread(
-                self._run_gallery_dl_download,
-                canonical_url,
-                download_path,
-                fallback_prefix,
-                cookies_path,
-                credentials,
-            )
-            if gallery_error:
-                if cookies_path and cookies_path.exists():
-                    cookies_path.unlink(missing_ok=True)
-                raise InstagramDownloadError(
-                    f"fallback через авторизацию не смог скачать медиа: yt-dlp: {message}; gallery-dl: {gallery_error}"
-                ) from last_error
-
-            last_error = None
-
-        files = self._files_for_shortcode(download_path, fallback_prefix)
-        media_files = [file_path for file_path in files if file_path.suffix.lower() in FALLBACK_MEDIA_EXTENSIONS]
-        non_media_files = [file_path for file_path in files if file_path not in media_files]
-        self._cleanup_temp_files(non_media_files)
-
-        if not media_files:
-            self._cleanup_temp_files(files)
-            if cookies_path and cookies_path.exists():
-                cookies_path.unlink(missing_ok=True)
-            raise InstagramNoMediaError("fallback через cookies завершился без медиафайлов.")
-
-        caption = self._caption_from_ytdlp_info(info)
-        self._cleanup_old_files(download_path, shortcode)
-        media_files = self._move_fallback_files(media_files, download_path, shortcode)
-
-        if caption:
-            (download_path / f"{shortcode}.txt").write_text(caption, encoding="utf-8")
-
-        if cookies_path and cookies_path.exists():
-            cookies_path.unlink(missing_ok=True)
-
-        return InstagramPost(
-            shortcode=shortcode,
-            canonical_url=canonical_url,
-            caption=caption,
-            media=[
-                InstagramMedia(
-                    url=file_path.as_uri(), is_video=file_path.suffix.lower() in VIDEO_EXTENSIONS, index=index
-                )
-                for index, file_path in enumerate(media_files, start=1)
-            ],
-        )
-
-    def _run_ytdlp_download(self, url: str, ydl_opts: dict[str, Any]) -> dict[str, Any] | None:
-        with YoutubeDL(ydl_opts) as ydl:  # type: ignore[arg-type]
-            return ydl.extract_info(url, download=True)  # type: ignore[no-any-return]
-
-    def _run_gallery_dl_download(
-        self,
-        url: str,
-        download_path: Path,
-        fallback_prefix: str,
-        cookies_path: Path | None,
-        credentials: tuple[str, str] | None,
-    ) -> str | None:
-        tmp_dir = download_path / f"{fallback_prefix}_gallery"
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-
-        cmd = [
-            sys.executable,
-            "-m",
-            "gallery_dl",
-            "--no-colors",
-            "--no-part",
-            "--force-ipv4",
-            "--retries",
-            str(FALLBACK_RETRIES),
-            "--http-timeout",
-            "30",
-            "-D",
-            str(tmp_dir),
-        ]
-
-        if cookies_path:
-            cmd.extend(("--cookies", str(cookies_path)))
-            logger.info("Trying gallery-dl Instagram fallback with saved cookies")
-        elif credentials:
-            username, password = credentials
-            cmd.extend(("--username", username, "--password", password))
-            logger.info("Trying gallery-dl Instagram fallback with configured credentials")
-
-        cmd.append(url)
-
-        try:
-            completed = subprocess.run(
-                cmd,
-                capture_output=True,
-                check=False,
-                encoding="utf-8",
-                errors="replace",
-                text=True,
-                timeout=180,
-            )
-        except Exception as exc:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            return self._clean_ytdlp_error(str(exc))
-
-        output = (completed.stderr or completed.stdout or "").strip()
-        if completed.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            return self._clean_ytdlp_error(output or f"exit code {completed.returncode}")
-
-        moved_count = 0
-        for source_path in sorted(tmp_dir.rglob("*")):
-            if not source_path.is_file():
-                continue
-
-            suffix = source_path.suffix.lower()
-            target_path = download_path / f"{fallback_prefix}_gallery_{moved_count + 1:02d}{suffix}"
-            shutil.move(str(source_path), target_path)
-            moved_count += 1
-
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
-        if moved_count == 0:
-            return "gallery-dl finished without files"
-
-        return None
-
-    def _configured_credentials(self) -> tuple[str, str] | None:
-        username = (INSTAGRAM_USERNAME or "").strip()
-        password = (INSTAGRAM_PASSWORD or "").strip()
-        if not username or username.lower() == "username" or not password:
-            return None
-        return username, password
-
-    def _files_for_shortcode(self, download_path: Path, shortcode: str) -> list[Path]:
-        return [
-            file_path
-            for file_path in download_path.iterdir()
-            if file_path.is_file() and file_path.name.startswith(shortcode) and not file_path.name.endswith(".part")
-        ]
-
-    def _move_fallback_files(self, files: list[Path], download_path: Path, shortcode: str) -> list[Path]:
-        moved_files: list[Path] = []
-
-        for index, source_path in enumerate(sorted(files), start=1):
-            suffix = source_path.suffix.lower() or ".mp4"
-            file_name = f"{shortcode}{suffix}" if len(files) == 1 else f"{shortcode}_{index:02d}{suffix}"
-            final_path = download_path / file_name
-            shutil.move(str(source_path), final_path)
-            moved_files.append(final_path)
-
-        return moved_files
-
-    def _cleanup_temp_files(self, files: list[Path]) -> None:
-        for file_path in files:
-            file_path.unlink(missing_ok=True)
-
-    def _caption_from_ytdlp_info(self, info: dict[str, Any] | None) -> str | None:
-        if not info:
-            return None
-
-        for key in ("description", "title"):
-            value = info.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-
-        return None
-
-    def _clean_ytdlp_error(self, error: str) -> str:
-        cleaned = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", error)
-        cleaned = re.sub(r"\s+", " ", cleaned.replace("\r", " ").replace("\n", " ")).strip()
-        if cleaned.startswith("ERROR:"):
-            cleaned = cleaned.removeprefix("ERROR:").strip()
-        return cleaned[:300] + "..." if len(cleaned) > 300 else cleaned
-
-    def _is_retryable_download_error(self, error: str) -> bool:
-        error_lower = error.lower()
-        return any(
-            marker in error_lower
-            for marker in (
-                "failed to resolve",
-                "getaddrinfo failed",
-                "temporary failure",
-                "timed out",
-                "timeout",
-                "connection aborted",
-                "connection reset",
-            )
-        )
 
     async def _resolve_shortcode(self, session: InstagramHttpSession, url: str) -> tuple[str, str]:
         match = re.search(r"/(p|reel|tv)/([\w-]+)", url)
@@ -1182,7 +839,7 @@ async def init_instaloader() -> InstagramWebDownloader:
     The public name is kept for backwards compatibility with existing routers.
     """
     http_preset = get_httpcloak_preset_name()
-    user_agent = os.getenv(HTTPCLOAK_USER_AGENT_ENV, CHROME_149_USER_AGENT).strip() or CHROME_149_USER_AGENT
+    user_agent = CHROME_149_USER_AGENT
     logger.info(f"Initializing custom Instagram downloader with UA: {user_agent[:50]}...")
     logger.info(f"Initializing Instagram HTTPCloak session with preset: {http_preset}")
 

--- a/tg_bot/downloaders/instagram.py
+++ b/tg_bot/downloaders/instagram.py
@@ -27,16 +27,7 @@ REQUEST_RETRIES = 3
 CHROME_149_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
 )
-INSTAGRAM_HTTP_PRESET_NAME = "instagram-chrome149"
-INSTAGRAM_HTTP_PRESET_JSON = json.dumps(
-    {
-        "version": 1,
-        "preset": {
-            "name": INSTAGRAM_HTTP_PRESET_NAME,
-            "extends": "chrome-149-windows",
-        },
-    }
-)
+INSTAGRAM_HTTP_PRESET_NAME = "chrome-149-windows"
 
 
 class InstagramDownloadError(Exception):
@@ -90,6 +81,7 @@ class InstagramHttpSession:
             timeout=REQUEST_TIMEOUT,
             retry=REQUEST_RETRIES,
             prefer_ipv4=True,
+            local_address="0.0.0.0",
             http_version="auto",
         )
 
@@ -168,12 +160,7 @@ class InstagramHttpSession:
 
 
 def get_httpcloak_preset_name() -> str:
-    try:
-        return httpcloak.load_preset_from_json(INSTAGRAM_HTTP_PRESET_JSON)
-    except Exception as exc:
-        if "already" not in str(exc).lower() and "exist" not in str(exc).lower():
-            logger.warning(f"Failed to register Instagram HTTPCloak preset: {exc}")
-        return INSTAGRAM_HTTP_PRESET_NAME
+    return INSTAGRAM_HTTP_PRESET_NAME
 
 
 class InstagramWebDownloader:

--- a/tg_bot/downloaders/ytdlp.py
+++ b/tg_bot/downloaders/ytdlp.py
@@ -1,3 +1,4 @@
+import re
 import traceback
 from pathlib import Path
 
@@ -11,6 +12,11 @@ MAX_SIZE_MB = 49  # 49 MB (Telegram limit is 50MB)
 MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024
 MAX_HEIGHT = 1440  # 2K max resolution
 MIN_HEIGHT = 480  # Minimum height
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _clean_error_text(error: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", error).strip()
 
 
 async def download_with_ytdlp(
@@ -129,9 +135,12 @@ async def download_with_ytdlp(
                     return False
 
                 title = downloaded.get("title")
-                entries = downloaded["entries"] if "entries" in downloaded else [downloaded]
+                entries = downloaded.get("entries") if isinstance(downloaded.get("entries"), list) else [downloaded]
 
                 for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+
                     file_path = Path(ydl.prepare_filename(entry))  # type: ignore
                     files.append(file_path)
 
@@ -161,7 +170,7 @@ async def download_with_ytdlp(
                 return True
 
         except Exception as e:
-            error = str(e)
+            error = _clean_error_text(str(e))
 
             if with_cookies:
                 logger.exception(f"Download with cookies failed: {e}")
@@ -170,7 +179,6 @@ async def download_with_ytdlp(
             if cookies_manager.has_cookies_error(error):
                 site_name = cookies_manager.get_site_name(url)
                 logger.warning(f"Cookies required for {site_name}")
-                await cookies_manager.mark_cookies_expired(site_name)
                 return False
 
             logger.error(f"yt-dlp error: {traceback.format_exc()}")

--- a/tg_bot/downloaders/ytdlp.py
+++ b/tg_bot/downloaders/ytdlp.py
@@ -184,7 +184,8 @@ async def download_with_ytdlp(
                     pass
 
     # Try download
-    if use_cookies and await _download_attempt(with_cookies=True):
+    if use_cookies:
+        await _download_attempt(with_cookies=True)
         return files, title, error
 
     if await _download_attempt(with_cookies=False):

--- a/uv.lock
+++ b/uv.lock
@@ -714,6 +714,18 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcloak"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/74/e574b3d3bdcd36d3a12955bbfcc755aa50e5ff6f588bd0c59c791eefe14a/httpcloak-1.6.7-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:54f45574fdc39506e01480676b999900843aa9a70d5482a8b6aa9ad3c22abf2b", size = 4901176, upload-time = "2026-06-03T10:48:44.699Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b8/032620d2fcaeea6b03806b3219c1e3c62a126157e664bbf3c7c60dd04f2c/httpcloak-1.6.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:55bcb1a3f101403098026f5000db312beb0c31809ffbd3a0ed562c2f68606df6", size = 4498688, upload-time = "2026-06-03T10:48:46.101Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f6/a33150ae28c7e698b1d0bd397d02786050f5a9f495c1588a747ec9aa0575/httpcloak-1.6.7-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c700f1ca6d88e07799877d80d2b9d7ba58f6cf2ce57383d89efbd22ff0ec68b1", size = 4676997, upload-time = "2026-06-03T10:48:47.469Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/1e/10f216469ee6b1407b6b132f6f0a971b2c804259ebb2d2f0933133f1031e/httpcloak-1.6.7-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:53acffa6590bd85b1a8cf94b9292b166c071d078b1a18ef10bdd87253c4bb3f9", size = 5175904, upload-time = "2026-06-03T10:48:48.948Z" },
+    { url = "https://files.pythonhosted.org/packages/70/00/a5d5a1eb07a9956c97a457f9247a82e46d2b5870e8606b18470119ada82a/httpcloak-1.6.7-py3-none-win_amd64.whl", hash = "sha256:8d77f1d3f4e7d126e18c1f390c6ac7c55d55d9991d1c72c34a65387a5abebe4d", size = 4969109, upload-time = "2026-06-03T10:48:50.803Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1228,6 +1240,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "gallery-dl" },
     { name = "google-genai" },
+    { name = "httpcloak" },
     { name = "httpx" },
     { name = "instaloader" },
     { name = "loguru" },
@@ -1264,6 +1277,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.118.0" },
     { name = "gallery-dl", specifier = ">=1.30.8" },
     { name = "google-genai", specifier = ">=1.39.1" },
+    { name = "httpcloak", specifier = ">=1.6.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "instaloader", specifier = ">=4.14.2" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
Replaces the broken Instaloader-based Instagram downloader with a custom curl-cffi web downloader.

Changes:
- resolves normal and share Instagram links
- downloads public post/reel/tv media
- supports carousel media
- preserves the existing downloader_manager contract
- keeps old public function names for router compatibility

Validation:
- ruff format --line-length 120 tg_bot/downloaders/instagram.py
- ruff check --fix tg_bot/downloaders/instagram.py
- python -m py_compile tg_bot/downloaders/instagram.py